### PR TITLE
Remove seemingly unnecessary install step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Once installed, you can build perspective via:
 
 ```bash
 npm install
-./node_modules/.bin/lerna bootstrap --hoist
 ./node_modules/.bin/lerna run start --stream
 ```
 


### PR DESCRIPTION
Just cloned and installed, and `npm install` seems to already run `lerna bootstrap --hoist`
```
:~$ git clone git@github.com:loicbourgois/perspective.git
Cloning into 'perspective'...
remote: Counting objects: 1692, done.
remote: Compressing objects: 100% (94/94), done.
remote: Total 1692 (delta 63), reused 112 (delta 49), pack-reused 1543
Receiving objects: 100% (1692/1692), 8.36 MiB | 1.31 MiB/s, done.
Resolving deltas: 100% (871/871), done.
:~$ cd perspective/
:~/perspective$ npm install

> undefined postinstall /home/user/perspective
> lerna bootstrap --hoist

lerna info version 2.8.0
lerna info Bootstrapping 7 packages
lerna info lifecycle preinstall
lerna info Installing external dependencies
lerna info hoist Installing hoisted dependencies into root
lerna info hoist Pruning hoisted dependencies
lerna info hoist Finished pruning hoisted dependencies
lerna info hoist Finished installing in root
lerna info Symlinking packages and binaries
lerna info lifecycle postinstall
lerna info lifecycle prepublish
lerna info lifecycle prepare
lerna success Bootstrapped 7 packages
npm WARN perspective No repository field.
npm WARN perspective No license field.

added 301 packages in 55.464s
```

So running a second time seems unecessary : 
```
:~/perspective$ ./node_modules/.bin/lerna bootstrap --hoist
lerna info version 2.8.0
lerna info Bootstrapping 7 packages
lerna info lifecycle preinstall
lerna info Installing external dependencies
lerna info hoist Pruning hoisted dependencies
lerna info hoist Finished pruning hoisted dependencies
lerna info hoist Finished installing in root
lerna info Symlinking packages and binaries
lerna info lifecycle postinstall
lerna info lifecycle prepublish
lerna info lifecycle prepare
lerna success Bootstrapped 7 packages
```