### PR TITLE
Refactored Highcharts imports to use heatmap module from base package.

### DIFF
--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -37,6 +37,7 @@
     "babel-runtime": "^6.26.0",
     "chroma-js": "^1.3.4",
     "highcharts": "5.0.14",
+    "highcharts-more": "^0.1.2",
     "highcharts-grouped-categories": "1.1.2"
   },
   "devDependencies": {

--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -37,9 +37,7 @@
     "babel-runtime": "^6.26.0",
     "chroma-js": "^1.3.4",
     "highcharts": "5.0.14",
-    "highcharts-grouped-categories": "1.1.2",
-    "highcharts-heatmap": "^0.1.2",
-    "highcharts-more": "^0.1.2"
+    "highcharts-grouped-categories": "1.1.2"
   },
   "devDependencies": {
     "@jpmorganchase/perspective": "^0.1.1",

--- a/packages/perspective-viewer-highcharts/src/js/heatmap.js
+++ b/packages/perspective-viewer-highcharts/src/js/heatmap.js
@@ -8,12 +8,14 @@
  */
 
 import highcharts from 'highcharts';
-import highchartsMore from 'highcharts-more';
-import highchartsHeatmap from 'highcharts-heatmap';
+import heatmap from 'highcharts/modules/heatmap';
+import grouped_categories from 'highcharts-grouped-categories';
+import chroma from 'chroma-js';
 
-highchartsHeatmap(highcharts);
-highchartsMore(highcharts);
 const Highcharts = highcharts;
+
+heatmap(highcharts);
+grouped_categories(highcharts);
 
 // cache prototypes
 let axisProto = Highcharts.Axis.prototype,
@@ -24,9 +26,6 @@ let axisProto = Highcharts.Axis.prototype,
     protoAxisRender = axisProto.render,
     UNDEFINED = void 0;
 
-
-require('highcharts-grouped-categories')(Highcharts);
-const chroma = require('chroma-js');
 
 export const COLORS_10 = ['#1f77b4','#ff7f0e','#2ca02c','#d62728','#9467bd','#8c564b','#e377c2','#7f7f7f','#bcbd22','#17becf'];
 export const COLORS_20 = [

--- a/packages/perspective-viewer-highcharts/src/js/heatmap.js
+++ b/packages/perspective-viewer-highcharts/src/js/heatmap.js
@@ -8,14 +8,12 @@
  */
 
 import highcharts from 'highcharts';
+import highchartsMore from 'highcharts-more';
 import heatmap from 'highcharts/modules/heatmap';
 import grouped_categories from 'highcharts-grouped-categories';
 import chroma from 'chroma-js';
 
 const Highcharts = highcharts;
-
-heatmap(highcharts);
-grouped_categories(highcharts);
 
 // cache prototypes
 let axisProto = Highcharts.Axis.prototype,
@@ -26,6 +24,9 @@ let axisProto = Highcharts.Axis.prototype,
     protoAxisRender = axisProto.render,
     UNDEFINED = void 0;
 
+highchartsMore(highcharts);
+heatmap(highcharts);
+grouped_categories(highcharts);
 
 export const COLORS_10 = ['#1f77b4','#ff7f0e','#2ca02c','#d62728','#9467bd','#8c564b','#e377c2','#7f7f7f','#bcbd22','#17becf'];
 export const COLORS_20 = [


### PR DESCRIPTION
Added tests and fixed overlap regression with bubble charts, as it does not seem these are in /modules yet.