### PR TITLE
Added 'remove' command to perspective.table

### DIFF
--- a/packages/perspective/src/cpp/main.cpp
+++ b/packages/perspective/src/cpp/main.cpp
@@ -503,7 +503,8 @@ make_table(
     val j_data,
     t_uint32 offset,
     t_str index,
-    t_bool is_arrow
+    t_bool is_arrow,
+    t_bool is_delete
 ) {
     // Create the input and port schemas
     t_svec colnames = vecFromJSArray<std::string>(j_colnames);
@@ -518,8 +519,13 @@ make_table(
     _fill_data(tbl, colnames, j_data, dtypes, offset, is_arrow);
 
     // Set up pkey and op columns
-    auto op_col = tbl->add_column("psp_op", DTYPE_UINT8, false);
-    op_col->raw_fill<t_uint8>(OP_INSERT);
+    if (is_delete) {
+        auto op_col = tbl->add_column("psp_op", DTYPE_UINT8, false);
+        op_col->raw_fill<t_uint8>(OP_DELETE);
+    } else {
+        auto op_col = tbl->add_column("psp_op", DTYPE_UINT8, false);
+        op_col->raw_fill<t_uint8>(OP_INSERT);
+    }
 
     if (index == "")
     {

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1071,10 +1071,52 @@ table.prototype.update = function (data) {
     try {
         tbl = __MODULE__.make_table(pdata.row_count || 0, 
             pdata.names, pdata.types, pdata.cdata,
-            this.gnode.get_table().size(), this.index || "", pdata.is_arrow);
+            this.gnode.get_table().size(), this.index || "", pdata.is_arrow, false);
 
         // Add any computed columns
         this._calculate_computed(tbl, this.computed);
+
+        __MODULE__.fill(this.pool, this.gnode, tbl);
+        this.initialized = true;
+    } catch (e) {
+        console.error(e);
+    } finally {
+        if (tbl) {
+            tbl.delete();
+        }
+        schema.delete();
+        types.delete();
+    }
+}
+
+/**
+ * Removes the rows of a {@link table}.  Removed rows are pushed down to any
+ * derived {@link view} objects.
+ *
+ * @param {Array<Object>} data An array of primary keys to remove.
+ *
+ * @see {@link table}
+ */
+table.prototype.remove = function (data) {
+    let pdata;
+    let cols = this._columns();
+    let schema = this.gnode.get_tblschema();
+    let types = schema.types();
+
+    data = data.map(idx => ({[this.index]: idx}));
+
+    if (data instanceof ArrayBuffer) {
+        pdata = load_arrow_buffer(data, [this.index], types);
+    }
+    else {
+        pdata = parse_data(data, [this.index], types);
+    }
+
+    let tbl;
+    try {
+        tbl = __MODULE__.make_table(pdata.row_count || 0, 
+            pdata.names, pdata.types, pdata.cdata,
+            this.gnode.get_table().size(), this.index || "", pdata.is_arrow, true);
 
         __MODULE__.fill(this.pool, this.gnode, tbl);
         this.initialized = true;
@@ -1403,7 +1445,7 @@ const perspective = {
             // Fill t_table with data
             tbl = __MODULE__.make_table(pdata.row_count || 0,
                 pdata.names, pdata.types, pdata.cdata,
-                0, options.index, pdata.is_arrow);
+                0, options.index, pdata.is_arrow, false);
 
             gnode = __MODULE__.make_gnode(tbl);
             pool.register_gnode(gnode);

--- a/packages/perspective/src/js/perspective.parallel.js
+++ b/packages/perspective/src/js/perspective.parallel.js
@@ -160,6 +160,8 @@ table.prototype.delete = async_queue('delete', "table_method");
 
 table.prototype.on_delete = subscribe('on_delete', 'table_method', true);
 
+table.prototype.remove = async_queue('remove', "table_method");
+
 table.prototype.update = function(data) {
     return new Promise( (resolve, reject) => {
         this._worker.handlers[++this._worker.msg_id] = {resolve, reject};

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -50,6 +50,30 @@ var arrow_indexed_result = [
 
 module.exports = (perspective) => {
 
+
+    describe("Removes", function() {
+
+        it("after an `update()`", async function () {
+            var table = perspective.table(meta, {index: "x"});
+            table.update(data);
+            var view = table.view();
+            table.remove([1, 2]);
+            let result = await view.to_json();
+            expect(result.length).toEqual(2);
+            expect(data.slice(2, 4)).toEqual(result);
+        });
+
+        it("after an regular data load`", async function () {
+            var table = perspective.table(data, {index: "x"});
+            var view = table.view();
+            table.remove([1, 2]);
+            let result = await view.to_json();
+            expect(result.length).toEqual(2);
+            expect(data.slice(2, 4)).toEqual(result);
+        });
+
+    });
+
     describe("Updates", function() {
 
         it("Meta constructor then `update()`", async function () {


### PR DESCRIPTION
Adds a 'remove' command, which takes a list of primary keys, of the type of the column specified by the 'index' attribute., to remove from a `perspective.table`.  Fixed #56  (delete method name is already taken and deletes the component itself).  