### PR TITLE
Ignore boost in perspective cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ flycheck_*.el
 *.out
 *.app
 
+packages/perspective/src/include/boost
 build
 CMakeCache.txt
 CMakeFiles


### PR DESCRIPTION
Small DX improvement if you have to copy boost headers into the project. 