### PR TITLE
Made y_area charts stacked by default

### DIFF
--- a/packages/perspective-viewer-highcharts/src/js/config.js
+++ b/packages/perspective-viewer-highcharts/src/js/config.js
@@ -141,6 +141,10 @@ export function default_config(aggregates, mode, js, col_pivots) {
             enabled: false
         },
         plotOptions: {
+            area: {
+                stacking: 'normal',
+                marker: {enabled: false, radius: 0}
+            },
             line: {
                 marker: {enabled: false, radius: 0}
             },


### PR DESCRIPTION
The UX/API around this is due for a refresh, but in the meantime it makes sense (IMHO) that stacked area charts are more useful than non-stacked area charts, at least across column pivots.

Fixes #89 