### PR TITLE
WIP - Hypergrid3

### DIFF
--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -56,9 +56,7 @@ module.exports = require('datasaur-local').extend('PerspectiveDataModel', {
         return config.grid.cellRenderers.get(rendererName);
     },
 
-    _cache_update: function() {
-        return Promise.resolve();
-    }
+    pspFetch: async function() {}
 });
 
 function fetchRows(rectangles, callback, ordinal, reason) {
@@ -68,7 +66,7 @@ function fetchRows(rectangles, callback, ordinal, reason) {
     }
 
     const promises = rectangles.map(
-        rect => this._cache_update(Range.create(rect.origin.y, rect.corner.y + 20))
+        rect => this.pspFetch(Range.create(rect.origin.y, rect.corner.y + 2))
     );
 
     Promise.all(promises)

--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -43,6 +43,12 @@ module.exports = require('datasaur-local').extend('PerspectiveDataModel', {
     // Note that `reason` comes from catch() albeit not used herein.
     fetchData: function(rectangles, callback, ordinal, reason) {
         if (!ordinal) {
+            if (!rectangles.find(uncachedRow, this)) {
+                // no uncached rows so all rows available so do nothing
+                callback(false); // falsy means success
+                return;
+            }
+
             // this is a new fetch request (as opposed to a retry)
             ordinal = ++this.fetchOrdinal;
         }
@@ -78,6 +84,14 @@ module.exports = require('datasaur-local').extend('PerspectiveDataModel', {
 
     pspFetch: async function() {}
 });
+
+function uncachedRow(rect) {
+    for (var r = rect.origin.y, R = Math.min(rect.corner.y + 2, this.getRowCount()); r < R; ++r) {
+        if (!this.data[r]) {
+            return true;
+        }
+    }
+}
 
 function cellStyle(gridCellConfig, rendererName) {
     if (gridCellConfig.value === null || gridCellConfig.value === undefined) {

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -50,7 +50,7 @@ function setPSP(payload) {
 
     this.grid.properties.showTreeColumn = payload.isTree;
 
-  
+
 
     console.log('Setting up initial schema and data load into HyperGrid');
 
@@ -61,7 +61,7 @@ function setPSP(payload) {
     // into `this` (behavior instance) to complete the setup before the event is dispatched.
     this.createColumns = createColumns;
 
-    grid.setData({
+    grid.behavior.setData({
         data: payload.rows,
         schema: new_schema
     });

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -48,9 +48,10 @@ function setPSP(payload) {
     // into `this` (behavior instance) to complete the setup before the event is dispatched.
     this.createColumns = createColumns;
 
-    this.dataModel.reset();
-
-    this.schema = new_schema;
+    this.grid.setData({
+        data: payload.rows,
+        schema: new_schema
+    });
 }
 
 /**

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -9,24 +9,16 @@
 
 'use strict';
 
-const _ = require('underscore');
-
-
 /**
  * @this {Behavior}
  * @param payload
  */
 function setPSP(payload) {
-    const grid = this.grid;
     const new_schema = [];
-
-    if (payload.columnPaths[0].length === 0 || payload.columnPaths[0][0] === '') {
-        payload.columnPaths[0] = [' '];
-    }
 
     if (payload.isTree) {
         new_schema[this.treeColumnIndex] = {
-            name: this.treeColumnIndex,
+            name: this.treeColumnIndex.toString(),
             header: ' ' // space char because empty string defaults to `name`
         };
     }
@@ -38,14 +30,11 @@ function setPSP(payload) {
 
         const col_name = columnPath.join('|'),
             aliases = payload.configuration.columnAliases,
-            col_header = aliases ? (aliases[col_name] || col_name) : col_name,
+            header = aliases && aliases[col_name] || col_name,
+            name = columnIndex.toString(),
             type = payload.columnTypes[columnIndex];
 
-        new_schema.push({
-            name: columnIndex.toString(),
-            header: col_header,
-            type: type
-        });
+        new_schema.push({ name, header, type });
     });
 
     this.grid.properties.showTreeColumn = payload.isTree;
@@ -59,7 +48,7 @@ function setPSP(payload) {
     // into `this` (behavior instance) to complete the setup before the event is dispatched.
     this.createColumns = createColumns;
 
-    grid.behavior.schema = new_schema;
+    this.schema = new_schema;
 
 }
 

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -50,8 +50,6 @@ function setPSP(payload) {
 
     this.grid.properties.showTreeColumn = payload.isTree;
 
-
-
     console.log('Setting up initial schema and data load into HyperGrid');
 
     this.stashedWidths = stashColumnWidths.call(this);
@@ -61,10 +59,7 @@ function setPSP(payload) {
     // into `this` (behavior instance) to complete the setup before the event is dispatched.
     this.createColumns = createColumns;
 
-    grid.behavior.setData({
-        data: payload.rows,
-        schema: new_schema
-    });
+    grid.behavior.schema = new_schema;
 
 }
 

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -48,8 +48,9 @@ function setPSP(payload) {
     // into `this` (behavior instance) to complete the setup before the event is dispatched.
     this.createColumns = createColumns;
 
-    this.schema = new_schema;
+    this.dataModel.reset();
 
+    this.schema = new_schema;
 }
 
 /**

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -10,7 +10,7 @@ var conv = {
     date: 'date'
 };
 
-module.exports = function(data, schema, tschema, row_pivots, start = 0, end = undefined, length = undefined) {
+module.exports = function psp2hypergrid(data, schema, tschema, row_pivots) {
     if (data.length === 0) {
         let columns = Object.keys(schema);
         return {
@@ -30,43 +30,37 @@ module.exports = function(data, schema, tschema, row_pivots, start = 0, end = un
 
     let flat_columns = columnPaths.map(col => col.join(','));
 
-    let rows = [];
-    if (length) {
-        rows.length = length;
-    }
-    for (let idx = start; idx < (end || data.length); idx++) {
-        const row = data[idx];
-        if (row) {
-            // `dataRow` (element of `dataModel.data`) keys will be `index` here rather than
-            // `columnName` because pivoted data have obscure column names of little use to developer.
-            // This also allows us to override `dataModel.getValue` with a slightly more efficient version
-            // that doesn't require mapping the name through `dataModel.dataSource.schema` to get the index.
-            let dataRow = flat_columns.reduce(function(dataRow, columnName, index) {
-                dataRow[index] = row[columnName];
-                return dataRow;
-            }, {});
+    let rows = data.map(function(row, idx) {
+        // `dataRow` (element of `dataModel.data`) keys will be `index` here rather than
+        // `columnName` because pivoted data have obscure column names of little use to developer.
+        // This also allows us to override `dataModel.getValue` with a slightly more efficient version
+        // that doesn't require mapping the name through `dataModel.dataSource.schema` to get the index.
+        let dataRow = flat_columns.reduce(function(dataRow, columnName, index) {
+            dataRow[index] = row[columnName];
+            return dataRow;
+        }, {});
 
-            if (is_tree) {
-                if (row.__ROW_PATH__ === undefined) {
-                    row.__ROW_PATH__ = [];
-                }
-
-                let name = row.__ROW_PATH__[row.__ROW_PATH__.length - 1];
-                if (name === undefined && idx === 0) {
-                    name = 'TOTAL';
-                }
-
-                // Following stores the tree column under [-1] rather than ['Tree'] so our `getValue`
-                // override can access it using the tree column index rather than the tree column name.
-                dataRow[TREE_COLUMN_INDEX] = {
-                    rollup: name,
-                    rowPath: ['ROOT'].concat(row.__ROW_PATH__),
-                    isLeaf: row.__ROW_PATH__.length >= (data[idx + 1] ? data[idx + 1].__ROW_PATH__.length : 0)
-                };
+        if (is_tree) {
+            if (row.__ROW_PATH__ === undefined) {
+                row.__ROW_PATH__ = [];
             }
-            rows[idx] = dataRow;
+
+            let name = row.__ROW_PATH__[row.__ROW_PATH__.length - 1];
+            if (name === undefined && idx === 0) {
+                name = 'TOTAL';
+            }
+
+            // Following stores the tree column under [-1] rather than ['Tree'] so our `getValue`
+            // override can access it using the tree column index rather than the tree column name.
+            dataRow[TREE_COLUMN_INDEX] = {
+                rollup: name,
+                rowPath: ['ROOT'].concat(row.__ROW_PATH__),
+                isLeaf: row.__ROW_PATH__.length >= (data[idx + 1] ? data[idx + 1].__ROW_PATH__.length : 0)
+            };
         }
-    }
+
+        return dataRow;
+    });
 
     return {
         rows: rows,

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -22,13 +22,10 @@ module.exports = function psp2hypergrid(data, schema, tschema, row_pivots) {
         };
     }
 
-    var is_tree = data[0].hasOwnProperty('__ROW_PATH__');
+    var is_tree = !!row_pivots.length;
 
-    var columnPaths = Object.keys(data[0])
-        .filter(row => row !== '__ROW_PATH__')
-        .map(row => row.split(','));
-
-    let flat_columns = columnPaths.map(col => col.join(','));
+    var flat_columns = Object.keys(data[0]).filter(row => row !== '__ROW_PATH__');
+    var columnPaths = flat_columns.map(row => row.split(','));
 
     let rows = data.map(function(row, idx) {
         // `dataRow` (element of `dataModel.data`) keys will be `index` here rather than


### PR DESCRIPTION
### Work-In-Progress
* These commits resolve several issues and are safe to merge to `hypergrid3` branch
* `hypergrid3` branch itself **_not_ ready** to be merged to `master` (due to incompleteness & failing tests)

### To-do list from mtg
- [x] update `PerspectiveDataModel`:
    - [x] use queued fetch
    - [x] accurate row count
    - [x] accurate tree status
- [x] don’t shrink tree column width
- [x] invalidate data
    - [x] implement `dataModel.reset()` call with which app can invalidate currently cached data
    - [x] (also note that data model itself can dispatch events to tell Hypergrid when data has changed)
- [ ] implement a limit on column autosizing width
    - [x] `columnAutosizingMax: 400`
    - [x] `treeColumnAutosizingMax: 400`
- [x] properly autosize columns after pivot (without mouse hover)
    - [x] eliminate “flash” (don’t render before autosize happens)
- [x] single-line tree gets error [this items appears to have resolved itself before I got to it]
- [ ] grid ticker (`refreshAnimationFrame` event loop) should be stopped when not the current viewer
- [x] check resize functionality
- [ ] run clean test

### fin-hypergrid alpha
This PR is only part of the story; there have also been half a dozen new commits to the [fin-hypergrid 3.0.0 PR](https://github.com/fin-hypergrid/core/pull/695) — which branch has also squashed & pushed to the fin-hypergrid `alpha` branch, [as referenced](https://github.com/jpmorganchase/perspective/blob/hypergrid3/packages/perspective-viewer-hypergrid/package.json#L40-L41) from package.json. The `github:` references therein shall be simplified to SEMVER references (_i.e.,_ npm registry references) as a last step before merging.
