### PR TITLE
Refactored `load()` method to a Promise; updated expand/collapse API …

### DIFF
--- a/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
+++ b/packages/perspective-viewer-hypergrid/src/js/PerspectiveDataModel.js
@@ -79,9 +79,9 @@ module.exports = require('datasaur-local').extend('PerspectiveDataModel', {
                 }
             } else {
                 if (is_expanded) {
-                    this._view.close(row);
+                    this._view.collapse(row);
                 } else {
-                    this._view.open(row);
+                    this._view.expand(row);
                 }
             }
             let nrows = await this._view.num_rows();

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -365,9 +365,11 @@ global.registerPlugin('hypergrid', {
     selectMode: 'toggle',
     update: grid_update,
     deselectMode: 'pivots',
-    resize: function () {
+    resize: async function () {
         if (this.hypergrid) {
             this.hypergrid.canvas.resize();
+            let nrows = await this._view.num_rows();
+            this.hypergrid.behavior.dataModel.setDirty(nrows);
         }
     },
     delete: function () {

--- a/packages/perspective/src/js/api.js
+++ b/packages/perspective/src/js/api.js
@@ -70,9 +70,9 @@ view.prototype.collapse_to_depth = async_queue('collapse_to_depth');
 
 view.prototype.get_row_expanded = async_queue('get_row_expanded');
 
-view.prototype.open = async_queue('open');
+view.prototype.expand = async_queue('expand');
 
-view.prototype.close = async_queue('close');
+view.prototype.collapse = async_queue('collapse');
 
 view.prototype.delete = async_queue('delete');
 

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -746,13 +746,13 @@ view.prototype.get_row_expanded = async function (idx) {
 }
 
 /**
- * Opens the row at index `idx`.
+ * Expands the row at index `idx`.
  * 
  * @async
  *
  * @returns {Promise<void>} 
  */
-view.prototype.open = async function (idx) {
+view.prototype.expand = async function (idx) {
     if (this.nsides === 2 && this.ctx.unity_get_row_depth(idx) < this.config.row_pivot.length) {
         return this.ctx.open(__MODULE__.t_header.HEADER_ROW, idx);
     } else if (this.nsides < 2) {
@@ -761,13 +761,13 @@ view.prototype.open = async function (idx) {
 }
 
 /**
- * Closes the row at index `idx`.
+ * Collapses the row at index `idx`.
  * 
  * @async
  *
  * @returns {Promise<void>} 
  */
-view.prototype.close = async function (idx) {
+view.prototype.collapse = async function (idx) {
     if (this.nsides === 2) {
         return this.ctx.close(__MODULE__.t_header.HEADER_ROW, idx);
     } else {


### PR DESCRIPTION
…to be consistent.

This allows sane access to a `<perspective-viewer>`s `view` property, without timeout tricks, e.g.:

    element.load(data).then(() => {
        element.view.collapse_to_depth(0);
        element.notifyResize();
    });