### PR TITLE
1D charts generated from columnar data

### DIFF
--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -22,7 +22,9 @@ export const draw = (mode) => async function (el, view, task) {
     const aggregates = this._get_view_aggregates();
     const hidden = this._get_view_hidden(aggregates);
 
-    const [js, schema, tschema] = await Promise.all([view.to_json(), view.schema(), this._table.schema()]);
+    const [js, cols, schema, tschema] = await Promise.all([view.to_json(), view.to_columns(), view.schema(), this._table.schema()]);
+    console.log(js);
+    console.log(cols);
 
     if (task.cancelled) {
         return;
@@ -122,7 +124,7 @@ export const draw = (mode) => async function (el, view, task) {
         set_both_axis(config, 'yAxis', yaxis_name, yaxis_type, yaxis_type, ytop);
     } else {
         let config = configs[0] = default_config.call(this, aggregates, mode, js, col_pivots);
-        let [series, top, ] = make_y_data(js, row_pivots, hidden);
+        let [series, top, ] = make_y_data(cols, row_pivots, hidden);
         config.series = series;
         config.colors = series.length <= 10 ? COLORS_10 : COLORS_20;        
         config.legend.enabled = col_pivots.length > 0 || series.length > 1;

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -23,8 +23,6 @@ export const draw = (mode) => async function (el, view, task) {
     const hidden = this._get_view_hidden(aggregates);
 
     const [js, cols, schema, tschema] = await Promise.all([view.to_json(), view.to_columns(), view.schema(), this._table.schema()]);
-    console.log(js);
-    console.log(cols);
 
     if (task.cancelled) {
         return;

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -13,7 +13,7 @@ import "../less/highcharts.less";
 
 import {COLORS_10, COLORS_20} from "./externals.js";
 import {color_axis} from "./color_axis.js";
-import {make_tree_data, make_y_data, make_y_columnar_data, make_xy_data, make_xyz_data} from "./series.js";
+import {make_tree_data, make_y_data, make_xy_data, make_xyz_data} from "./series.js";
 import {set_boost, set_axis, set_category_axis, set_both_axis, default_config, set_tick_size} from "./config.js";
 
 export const draw = (mode) => async function (el, view, task) {
@@ -122,7 +122,7 @@ export const draw = (mode) => async function (el, view, task) {
         set_both_axis(config, 'yAxis', yaxis_name, yaxis_type, yaxis_type, ytop);
     } else {
         let config = configs[0] = default_config.call(this, aggregates, mode, js, col_pivots);
-        let [series, top, ] = make_y_columnar_data(cols, row_pivots, hidden);
+        let [series, top, ] = make_y_data(cols, row_pivots, hidden);
         config.series = series;
         config.colors = series.length <= 10 ? COLORS_10 : COLORS_20;        
         config.legend.enabled = col_pivots.length > 0 || series.length > 1;

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -13,7 +13,7 @@ import "../less/highcharts.less";
 
 import {COLORS_10, COLORS_20} from "./externals.js";
 import {color_axis} from "./color_axis.js";
-import {make_tree_data, make_y_data, make_xy_data, make_xyz_data} from "./series.js";
+import {make_tree_data, make_y_data, make_y_columnar_data, make_xy_data, make_xyz_data} from "./series.js";
 import {set_boost, set_axis, set_category_axis, set_both_axis, default_config, set_tick_size} from "./config.js";
 
 export const draw = (mode) => async function (el, view, task) {
@@ -122,7 +122,7 @@ export const draw = (mode) => async function (el, view, task) {
         set_both_axis(config, 'yAxis', yaxis_name, yaxis_type, yaxis_type, ytop);
     } else {
         let config = configs[0] = default_config.call(this, aggregates, mode, js, col_pivots);
-        let [series, top, ] = make_y_data(cols, row_pivots, hidden);
+        let [series, top, ] = make_y_columnar_data(cols, row_pivots, hidden);
         config.series = series;
         config.colors = series.length <= 10 ? COLORS_10 : COLORS_20;        
         config.legend.enabled = col_pivots.length > 0 || series.length > 1;

--- a/packages/perspective-viewer/src/js/row.js
+++ b/packages/perspective-viewer/src/js/row.js
@@ -252,7 +252,6 @@ class Row extends HTMLElement {
 
         let sort_order = this.querySelector('#sort_order');
         sort_order.addEventListener('click', event => {
-            // TODO: event loop optimizations to prevent hang on large graph redraws?
             const current = this.getAttribute('sort-order');
             const order = (perspective.SORT_ORDERS.indexOf(current) + 1) % 5;
             this.setAttribute('sort-order', perspective.SORT_ORDERS[order]);

--- a/packages/perspective-viewer/src/js/row.js
+++ b/packages/perspective-viewer/src/js/row.js
@@ -252,6 +252,7 @@ class Row extends HTMLElement {
 
         let sort_order = this.querySelector('#sort_order');
         sort_order.addEventListener('click', event => {
+            // TODO: event loop optimizations to prevent hang on large graph redraws?
             const current = this.getAttribute('sort-order');
             const order = (perspective.SORT_ORDERS.indexOf(current) + 1) % 5;
             this.setAttribute('sort-order', perspective.SORT_ORDERS[order]);

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -645,8 +645,9 @@ const to_format = async function (options, formatter) {
  * "row_pivots" config parameter supplied when constructed, each row Object
  * will have a "__ROW_PATH__" key, whose value specifies this row's
  * aggregated path.  If this {@link view} had a "column_pivots" config
- * parameter supplied, the keys of this object will be comma-prepended with
- * their comma-separated column paths.
+ * parameter supplied, the keys of this object are both prepended and
+ * their column paths separated by `COLUMN_SEPARATOR_STRING` as set in
+ * `defaults.js`.
  */
 view.prototype.to_columns = async function (options) {
     return to_format.call(this, options, formatters.jsonTableFormatter);
@@ -671,9 +672,10 @@ view.prototype.to_columns = async function (options) {
  * representing the rows of this {@link view}.  If this {@link view} had a
  * "row_pivots" config parameter supplied when constructed, each row Object
  * will have a "__ROW_PATH__" key, whose value specifies this row's
- * aggregated path.  If this {@link view} had a "column_pivots" config
- * parameter supplied, the keys of this object will be comma-prepended with
- * their comma-separated column paths.
+ * aggregated path.   If this {@link view} had a "column_pivots" config
+ * parameter supplied, the keys of this object are both prepended and
+ * their column paths separated by `COLUMN_SEPARATOR_STRING` as set in
+ * `defaults.js`.
  */
 view.prototype.to_json = async function (options) {
     return to_format.call(this, options, formatters.jsonFormatter);


### PR DESCRIPTION
- Add axis generator and data parser for columnar data
- Rename old row-based methods for backward compatibility

*Merge only after `to_column` correctly strips total rows.* I included a `.filter()` inside `ColumnarIterator` that can be removed in order to verify that total rows are stripped. 