### PR TITLE
Fixed column-oriented output with column-only pivot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
   - npm install
 
 script:
-  - npm run lint
   - PSP_DOCKER=1 npm run build
   - PSP_DOCKER=1 npm run test:build
   - npm run test:run_quiet

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"test:build": "bash -c '[[ -z \"${PSP_DOCKER}\" ]] && npm run --silent _build_test || npm run --silent _emsdk -- npm run --silent _build_test'",
 		"test:run": "npm run --silent clean:screenshots && npm run --silent _puppeteer -- node_modules/.bin/lerna exec --concurrency 1 --no-bail ${PACKAGE:+--scope=@jpmorganchase/${PACKAGE}} -- npm run --silent test:run",
 		"test:run_quiet": "npm run --silent _puppeteer -- node_modules/.bin/lerna run test:run",
-		"test": "npm-run-all --silent test:build test:run",
+		"test": "npm-run-all --silent lint test:build test:run",
 		"clean": "lerna run clean --stream",
 		"clean:screenshots": "lerna run clean:screenshots ${PACKAGE:+--scope=@jpmorganchase/${PACKAGE}}",
 		"write_tests": "WRITE_TESTS=1 npm run test:run",

--- a/packages/perspective-viewer-hypergrid/test/results/results.json
+++ b/packages/perspective-viewer-hypergrid/test/results/results.json
@@ -11,5 +11,5 @@
     "superstore.html/resets viewable area when the physical size expands.": "5c9f7fcce4e9bb1f144409afbc43b0fa",
     "superstore.html/sorts by a hidden column.": "93293864b4d0670ba1e46ec5ff397d02",
     "superstore.html/filters by a numeric column.": "f3b7ca04028702596acabfbe46ca074c",
-    "superstore.html/pivots by a column.": "8370b9f653271729a384765e9a609584"
+    "superstore.html/pivots by a column.": "d1dce7a5d99e1760954bb99751e0a761"
 }

--- a/packages/perspective-viewer/src/js/view.js
+++ b/packages/perspective-viewer/src/js/view.js
@@ -734,6 +734,7 @@ class ViewPrivate extends HTMLElement {
         }
         this._show_config = !this._show_config;
         this._plugin.resize.call(this, true);
+        this.dispatchEvent(new CustomEvent('perspective-toggle-settings', {detail: this._show_config}));
     }
 
     _get_view_filters() {

--- a/packages/perspective/src/js/view_formatters.js
+++ b/packages/perspective/src/js/view_formatters.js
@@ -17,7 +17,7 @@ const jsonFormatter = {
     addColumnValue: (data, row, colName, value) => row[colName].unshift(value),
     addRow: (data, row) => data.push(row),
     formatData: data => data,
-    slice: (data, start, length) => data.slice(start, length)
+    slice: (data, start) => data.slice(start)
 };
 
 const csvFormatter = Object.assign({}, jsonFormatter, {
@@ -43,11 +43,12 @@ const jsonTableFormatter = {
     },
     addRow: () => {},
     formatData: data => data,
-    slice: (data, start, length) => {
+    slice: (data, start) => {
+        let new_data = {}
         for (let x in data) {
-            data[x].splice(start, length);
+            new_data[x] = data[x].slice(start);
         }
-        return data;
+        return new_data;
     }
 }
 

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -27,6 +27,12 @@ var data2 = [
     {'x': 4, 'y':2, 'z': false}
 ];
 
+var data_7 = {
+    'w': [1.5, 2.5, 3.5, 4.5],
+    'x': [1, 2, 3, 4],
+    'y': ['a', 'b', 'c', 'd'],
+    'z': [true, false, true, false]
+};
 
 module.exports = (perspective) => {
 
@@ -109,7 +115,7 @@ module.exports = (perspective) => {
             expect(answer).toEqual(result);
           });
   
-          it("['z'], last by index", async function () {
+        it("['z'], last by index", async function () {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivot: ['z'],
@@ -122,9 +128,9 @@ module.exports = (perspective) => {
             ];
             let result = await view.to_json();
             expect(answer).toEqual(result);
-          });
+        });
   
-          it("['z'], last", async function () {
+        it("['z'], last", async function () {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivot: ['z'],
@@ -149,9 +155,8 @@ module.exports = (perspective) => {
             ];
             let result2 = await view.to_json();
             expect(answerAfterUpdate).toEqual(result2);
-          });
+        });
   
-
     });
 
     describe("Aggregates with nulls", function () {
@@ -472,6 +477,38 @@ module.exports = (perspective) => {
             });
             let result2 = await view.schema();
             expect(meta).toEqual(result2);
+        });
+
+        it("['x'] only, column-oriented input", async function () {
+            var table = perspective.table(data_7);
+            var view = table.view({
+                column_pivot: ['z']
+            });
+            let result2 = await view.to_json();
+            expect(result2).toEqual([
+                {'true|w': 1.5, 'true|x': 1, 'true|y': 'a', 'true|z': true, 'false|w': null, 'false|x': null, 'false|y': null, 'false|z': null},
+                {'true|w': null, 'true|x': null, 'true|y': null, 'true|z': null, 'false|w': 2.5, 'false|x': 2, 'false|y': 'b', 'false|z': false},
+                {'true|w': 3.5, 'true|x': 3, 'true|y':'c', 'true|z': true, 'false|w': null, 'false|x': null, 'false|y': null, 'false|z': null},
+                {'true|w': null, 'true|x': null, 'true|y': null, 'true|z': null, 'false|w': 4.5, 'false|x': 4, 'false|y': 'd', 'false|z': false}
+            ]);
+        });
+
+        it("['x'] only, column-oriented output", async function () {
+            var table = perspective.table(data_7);
+            var view = table.view({
+                column_pivot: ['z']
+            });
+            let result2 = await view.to_columns();
+            expect(result2).toEqual({
+                'true|w': [1.5, null, 3.5, null], 
+                'true|x': [1, null, 3, null], 
+                'true|y': ['a', null, 'c', null],
+                'true|z': [true, null, true, null],
+                'false|w': [null, 2.5, null, 4.5], 
+                'false|x': [null, 2, null, 4],
+                'false|y': [null, 'b', null, 'd'],
+                'false|z': [null, false, null, false]
+            });
         });
 
         it("['x'] only", async function () {

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -78,10 +78,10 @@ module.exports = (perspective) => {
 
         it("multiple single element removes", async function () {
             let table = perspective.table(meta, {index: "x"});
-            for (let i = 0; i < 100; i++) {
+            for (let i = 0; i < 200; i++) {
                 table.update([{x: i, y: "test", z: false}]);
             }
-            for (let i = 1; i < 100; i++) {
+            for (let i = 1; i < 200; i++) {
                 table.remove([i]);
             }
             let view = table.view();
@@ -413,7 +413,6 @@ module.exports = (perspective) => {
                 {__ROW_PATH__: [ 2 ], y: 0},
             ]);
         });
-
 
         it('can be removed entirely', async function () {
             var table = perspective.table([


### PR DESCRIPTION
Fixed issue in column-oriented JSON output, when only a column pivot is applied, which caused additional rows in the output.