### PR TITLE
Limit tables

### DIFF
--- a/packages/perspective-examples/src/html/streaming.html
+++ b/packages/perspective-examples/src/html/streaming.html
@@ -14,6 +14,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
 
         <script src="mobile_fix.js"></script>
+        <script src="perspective.js"></script>
         <script src="perspective.view.js"></script>
         <script src="hypergrid.plugin.js"></script>
         <script src="highcharts.plugin.js"></script>
@@ -23,7 +24,7 @@
     </head>
     <body>
 
-        <perspective-viewer index='id' row-pivots='["name"]' column-pivots='["client"]' columns='["chg","vol"]'></perspective-viewer>
+        <perspective-viewer row-pivots='["name"]' column-pivots='["client"]' columns='["chg","vol"]'></perspective-viewer>
 
         <script>
 
@@ -55,8 +56,6 @@
                 "Krusty",
             ]
 
-            var id = 0;
-
             function newRows() {
                 rows = [];
                 for (var x = 0; x < 5; x ++) {
@@ -68,22 +67,20 @@
                         bid: Math.random() * 10 + 90,
                         ask: Math.random() * 10 + 100,
                         vol: Math.random() * 10 + 100,                    
-                        id: id
                     });
-                    id = (id + 1) % 500;
                 }
                 return rows;
             }
 
             window.addEventListener('WebComponentsReady', function () {
                 var elem = document.getElementsByTagName('perspective-viewer')[0]; 
+                var table = perspective.worker().table(newRows(), {limit: 500});
+                elem.load(table);
 
-                function postRow() {
+                (function postRow() {
                     elem.update(newRows());
                     setTimeout(postRow, 50);
-                }
-
-                postRow();
+                })();
             });
 
         </script>

--- a/packages/perspective-viewer/src/js/view.js
+++ b/packages/perspective-viewer/src/js/view.js
@@ -1185,19 +1185,6 @@ class View extends ViewPrivate {
     }
 
     /**
-     * The column name to index by.  Due to the mutable nature of 
-     * `perspective.table`, `index` cannot be modified once `load` or `update`
-     * has been called.
-     * 
-     * @type {string}
-     */
-    set index(index) {
-        if (this._table) {
-            console.error(`Setting 'index' attribute after initialization has no effect`);
-        }
-    }
-
-    /**
      * Sets this `perspective.table.view`'s `row_pivots` property.
      * 
      * @name row-pivots
@@ -1256,7 +1243,7 @@ class View extends ViewPrivate {
      */
     get worker() {
         if (this._table) {
-            return this._table.worker;
+            return this._table._worker;
         }
         return get_worker();
     }

--- a/packages/perspective-viewer/src/js/view.js
+++ b/packages/perspective-viewer/src/js/view.js
@@ -800,7 +800,9 @@ class ViewPrivate extends HTMLElement {
         if (this._table) {
             let table = this._table;
             this._table = undefined;
-            all.push(table.delete());
+            if (table._owner_viewer && table._owner_viewer === this) {
+                all.push(table.delete());
+            }
         }
         return Promise.all(all);
     }
@@ -1305,6 +1307,7 @@ class View extends ViewPrivate {
             table = data;
         } else {
             table = get_worker().table(data, options);
+            table._owner_viewer = this;
         }
         let _promises = [loadTable.call(this, table)];
         for (let slave of this._slaves) {

--- a/packages/perspective/src/cpp/main.cpp
+++ b/packages/perspective/src/cpp/main.cpp
@@ -538,6 +538,7 @@ make_table(
     val j_dtypes,
     val j_data,
     t_uint32 offset,
+    t_uint32 limit,
     t_str index,
     t_bool is_arrow,
     t_bool is_delete
@@ -572,8 +573,8 @@ make_table(
 
         for (auto ridx = 0; ridx < tbl->size(); ++ridx)
         {
-            key_col->set_nth<t_int32>(ridx, ridx + offset);
-            okey_col->set_nth<t_int32>(ridx, ridx + offset);
+            key_col->set_nth<t_int32>(ridx, (ridx + offset) % limit);
+            okey_col->set_nth<t_int32>(ridx, (ridx + offset) % limit);
         }
     } else {
         tbl->clone_column(index, "psp_pkey");

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -234,6 +234,25 @@ module.exports = (perspective) => {
 
     });
 
+    describe("Limit", function () {
+
+        it("{limit: 2} with table of size 4", async function () {
+            var table = perspective.table(data, {limit: 2});
+            var view = table.view();
+            let result = await view.to_json();
+            expect(data.slice(2)).toEqual(result);
+        });
+
+        it("{limit: 5} with 2 updates of size 4", async function () {
+            var table = perspective.table(data, {limit: 5});
+            table.update(data);
+            var view = table.view();
+            let result = await view.to_json();
+            expect(data.slice(1).concat(data.slice(3, 4)).concat(data.slice(0, 1))).toEqual(result);
+        });
+
+    });
+
     describe("Indexed", function() {
 
         it("{index: 'x'} (int)", async function () {


### PR DESCRIPTION
Added `limit` option to the `table` constructor, to limit the total number of rows on non-indexed tables.