### PR TITLE
Add webpack module entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ cmake-build-debug
 .ipynb_checkpoints
 
 package.json.lerna_backup
+packages/*/es

--- a/examples/api-usage/package.json
+++ b/examples/api-usage/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@perspective-examples/api-usage",
+  "private": true,
+  "version": "1.0.0",
+  "description": "An example of streaming random data into perspective",
+  "main": "index.js",
+  "scripts": {
+    "start": "npm-run-all -l -p start:*",
+    "start:server": "http-server dist",
+    "start:webpack": "webpack --watch --hot"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@jpmorganchase/perspective": "^0.2.0-beta.2"
+  },
+  "devDependencies": {
+    "http-server": "^0.11.1",
+    "webpack": "^4.19.1",
+    "webpack-cli": "^3.1.1",
+    "webpack-dev-server": "^3.1.8",
+    "copy-webpack-plugin": "^4.5.2"
+  }
+}

--- a/examples/api-usage/src/index.html
+++ b/examples/api-usage/src/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <h1>Open the console</h1>
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/examples/api-usage/src/index.js
+++ b/examples/api-usage/src/index.js
@@ -1,0 +1,50 @@
+const perspective = require("@jpmorganchase/perspective").default;
+
+const schema = {
+    name: "string",
+    client: "string",
+    lastUpdate: "date",
+    chg: "float",
+    bid: "float",
+    ask: "float",
+    vol: "float",
+    id: "integer"
+};
+
+var SECURITIES = ["AAPL.N", "AMZN.N", "QQQ.N", "NVDA.N", "TSLA.N", "FB.N", "MSFT.N", "TLT.N", "XIV.N", "YY.N", "CSCO.N", "GOOGL.N", "PCLN.N"];
+
+var CLIENTS = ["Homer", "Marge", "Bart", "Lisa", "Maggie", "Moe", "Lenny", "Carl", "Krusty"];
+
+function generateRow() {
+    return {
+        name: SECURITIES[Math.floor(Math.random() * SECURITIES.length)],
+        client: CLIENTS[Math.floor(Math.random() * CLIENTS.length)],
+        lastUpdate: new Date(),
+        chg: Math.random() * 20 - 10,
+        bid: Math.random() * 10 + 90,
+        ask: Math.random() * 10 + 100,
+        vol: Math.random() * 10 + 100,
+        id: Math.floor(Math.random() * 500)
+    };
+}
+
+const worker = perspective.worker();
+
+const table = worker.table(schema, {index: "id"});
+
+const view = table.view({
+    row_pivot: ["name"],
+    aggregate: Object.keys(schema).map(col => ({op: "last", column: col}))
+});
+
+view.on_update(data => console.table(data));
+
+for (let i = 0; i < 5; i += 1) {
+    setTimeout(() => {
+        const data = [];
+        for (let j = 0; j < i; j += 1) {
+            data.push(generateRow());
+            table.update(data);
+        }
+    }, Math.random() * 60);
+}

--- a/examples/api-usage/webpack.config.js
+++ b/examples/api-usage/webpack.config.js
@@ -1,0 +1,22 @@
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+
+module.exports = {
+    context: __dirname,
+    entry: "./src/index.js",
+    mode: "development",
+    plugins: [
+        new CopyWebpackPlugin([
+            {
+                from: "./src/index.html",
+            },
+            {
+                from: "./node_modules/@jpmorganchase/perspective/build/perspective.worker.*",
+                to: "[name].[ext]"
+            },
+            {
+                from: "./node_modules/@jpmorganchase/perspective/build/*.wasm",
+                to: "[name].[ext]"
+            }
+        ])
+    ]
+};

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,8 @@
 {
   "lerna": "2.5.1",
   "packages": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "version": "0.2.0-beta.2"
 }

--- a/packages/perspective-jupyterlab/src/js/embed.js
+++ b/packages/perspective-jupyterlab/src/js/embed.js
@@ -7,7 +7,7 @@
  *
  */
 
-import worker from "worker-loader?inline=true&fallback=false!@jpmorganchase/perspective/src/js/perspective.wasm.js";
+import worker from "worker-loader?inline=true&fallback=false!@jpmorganchase/perspective";
 import buffer from "arraybuffer-loader!@jpmorganchase/perspective/build/psp.async.wasm";
 
 window.__PSP_WORKER__ = worker;

--- a/packages/perspective-viewer-highcharts/src/js/series.js
+++ b/packages/perspective-viewer-highcharts/src/js/series.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
+import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective";
 
 function row_to_series(series, sname, gname) {
     let s;

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
+import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective";
 
 const TREE_COLUMN_INDEX = require("fin-hypergrid/src/behaviors/Behavior").prototype.treeColumnIndex;
 

--- a/packages/perspective-viewer/src/js/view.js
+++ b/packages/perspective-viewer/src/js/view.js
@@ -10,7 +10,7 @@ import "@webcomponents/webcomponentsjs";
 import _ from "underscore";
 import {polyfill} from "mobile-drag-drop";
 
-import perspective from "@jpmorganchase/perspective/src/js/perspective.parallel.js";
+import perspective from "@jpmorganchase/perspective";
 import {bindTemplate, json_attribute, array_attribute, copy_to_clipboard} from "./utils.js";
 
 import template from "../html/view.html";

--- a/packages/perspective/.babelrc
+++ b/packages/perspective/.babelrc
@@ -1,0 +1,17 @@
+{
+  "presets": [
+    "env"
+  ],
+  "plugins": [
+    "transform-decorators-legacy",
+    "transform-custom-element-classes",
+    "transform-runtime",
+    "transform-object-rest-spread",
+    [
+      "transform-es2015-for-of",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0-beta.2",
   "description": "Perspective.js",
   "main": "build/perspective.umd.js",
+  "module": "es/js/perspective.parallel.js",
   "publishConfig": {
     "access": "public"
   },
@@ -22,9 +23,11 @@
     "build": "npm-run-all build:compile:* build:copy:* build:webpack",
     "build:compile:copy": "mkdir -p obj build",
     "build:compile:emmake": "cd obj/ && emcmake cmake ../ && emmake make -j${PSP_CPU_COUNT-8}",
-    "build:copy:async": "cp obj/psp.async.wasm build/psp.async.wasm",
-    "build:copy:sync": "cp obj/psp.sync.wasm build/psp.sync.wasm",
-    "build:webpack": "npm-run-all -p build:webpack:*",
+    "build:copy:asm": "cp obj/psp.asmjs.js build/psp.asmjs.js",
+    "build:copy:async": "cp obj/psp.async.wasm build/psp.async.wasm && cp obj/psp.async.js build/psp.async.js",
+    "build:copy:sync": "cp obj/psp.sync.wasm build/psp.sync.wasm && cp obj/psp.sync.js build/psp.sync.js",
+    "build:webpack": "npm-run-all -l -p build:webpack:*",
+    "build:webpack:babel": "babel src/js --out-dir es/js",
     "build:webpack:asmjs": "webpack --color --config src/config/perspective.asmjs.config.js",
     "build:webpack:wasm": "webpack --color --config src/config/perspective.wasm.config.js",
     "build:webpack:parallel": "webpack --color --config src/config/perspective.parallel.config.js",
@@ -65,6 +68,7 @@
   "devDependencies": {
     "@apache-arrow/es5-esm": "^0.3.1",
     "arraybuffer-loader": "^1.0.2",
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-custom-element-classes": "^0.1.0",

--- a/packages/perspective/src/js/perspective.asmjs.js
+++ b/packages/perspective/src/js/perspective.asmjs.js
@@ -7,7 +7,7 @@
  *
  */
 
-const load_perspective = require("../../obj/psp.asmjs.js").load_perspective;
+const load_perspective = require("../../build/psp.asmjs.js").load_perspective;
 const perspective = require("./perspective.js");
 
 const Module = load_perspective({

--- a/packages/perspective/src/js/perspective.node.js
+++ b/packages/perspective/src/js/perspective.node.js
@@ -7,7 +7,7 @@
  *
  */
 
-import buffer from "../../obj/psp.sync.wasm";
+import buffer from "../../build/psp.sync.wasm";
 
 const perspective = require("./perspective.js");
 
@@ -17,7 +17,7 @@ const WebSocket = require("ws");
 
 const path = require("path");
 
-const load_perspective = require("../../obj/psp.sync.js").load_perspective;
+const load_perspective = require("../../build/psp.sync.js").load_perspective;
 
 let Module = load_perspective({
     wasmBinary: buffer,

--- a/packages/perspective/src/js/perspective.parallel.js
+++ b/packages/perspective/src/js/perspective.parallel.js
@@ -11,6 +11,9 @@ import {detectIE, ScriptPath} from "./utils.js";
 
 import {TYPE_AGGREGATES, AGGREGATE_DEFAULTS, TYPE_FILTERS, FILTER_DEFAULTS, SORT_ORDERS} from "./defaults.js";
 
+// other packages need this
+export {COLUMN_SEPARATOR_STRING} from "./defaults";
+
 import {worker} from "./api.js";
 
 /******************************************************************************

--- a/packages/perspective/src/js/perspective.wasm.js
+++ b/packages/perspective/src/js/perspective.wasm.js
@@ -7,7 +7,7 @@
  *
  */
 
-const load_perspective = require("../../obj/psp.async.js").load_perspective;
+const load_perspective = require("../../build/psp.async.js").load_perspective;
 const perspective = require("./perspective.js");
 
 if (global.document !== undefined && typeof WebAssembly !== "undefined") {

--- a/packages/perspective/test/js/perspective.spec.js
+++ b/packages/perspective/test/js/perspective.spec.js
@@ -17,7 +17,7 @@ const RUNTIMES = {
 };
 
 if (typeof WebAssembly !== "undefined") {
-    RUNTIMES["WASM"] = perspective(require("../../obj/psp.sync.js"));
+    RUNTIMES["WASM"] = perspective(require("../../build/psp.sync.js"));
 }
 
 const constructor_tests = require("./constructors.js");


### PR DESCRIPTION
This PR adds a webpack `module` entrypoint into the `package.json` for `@jpmorganchase/perspective` and refactors the internal packages to use it, rather than rely on importing internal source code to build packages. This has two positive effects:

1. Better code sharing between modules which use perspective at run time
2. The ability to consume perspective as a stand alone API module in webpack, once the appropriate javascript files have been copied into the output directory. 

I wasn't sure where to put the example, since it's much more of a stand alone project than the current examples, so I follow the convention that most other repos use and put it in `/examples/[name]`. 