### PR TITLE
Add 'not in' filter operation

### DIFF
--- a/packages/perspective/src/cpp/base.cpp
+++ b/packages/perspective/src/cpp/base.cpp
@@ -252,6 +252,9 @@ filter_op_to_str(t_filter_op op) {
         case FILTER_OP_IN: {
             return "in";
         } break;
+        case FILTER_OP_NOT_IN: {
+            return "not in";
+        } break;
         case FILTER_OP_AND: {
             return "and";
         } break;

--- a/packages/perspective/src/cpp/filter.cpp
+++ b/packages/perspective/src/cpp/filter.cpp
@@ -82,8 +82,9 @@ t_fterm::get_expr() const {
             ss << filter_op_to_str(m_op) << " ";
             ss << m_threshold.to_string(true);
         } break;
+        case FILTER_OP_NOT_IN:
         case FILTER_OP_IN: {
-            ss << " in (";
+            ss << " " << filter_op_to_str(m_op) << " (";
             for (auto v : m_bag) {
                 ss << v.to_string(true) << ", ";
             }

--- a/packages/perspective/src/cpp/main.cpp
+++ b/packages/perspective/src/cpp/main.cpp
@@ -84,6 +84,7 @@ _get_fterms(t_schema schema, val j_filters) {
         t_filter_op comp = filter[1].as<t_filter_op>();
 
         switch (comp) {
+            case FILTER_OP_NOT_IN:
             case FILTER_OP_IN: {
                 t_tscalvec terms{};
                 std::vector<std::string> j_terms = vecFromJSArray<std::string>(filter[2]);
@@ -1139,6 +1140,7 @@ EMSCRIPTEN_BINDINGS(perspective) {
         .value("FILTER_OP_CONTAINS", FILTER_OP_CONTAINS)
         .value("FILTER_OP_OR", FILTER_OP_OR)
         .value("FILTER_OP_IN", FILTER_OP_IN)
+        .value("FILTER_OP_NOT_IN", FILTER_OP_NOT_IN)
         .value("FILTER_OP_AND", FILTER_OP_AND)
         .value("FILTER_OP_IS_NAN", FILTER_OP_IS_NAN)
         .value("FILTER_OP_IS_NOT_NAN", FILTER_OP_IS_NOT_NAN)

--- a/packages/perspective/src/include/perspective/base.h
+++ b/packages/perspective/src/include/perspective/base.h
@@ -150,6 +150,7 @@ enum t_filter_op {
     FILTER_OP_CONTAINS,
     FILTER_OP_OR,
     FILTER_OP_IN,
+    FILTER_OP_NOT_IN,
     FILTER_OP_AND,
     FILTER_OP_IS_NAN,
     FILTER_OP_IS_NOT_NAN,

--- a/packages/perspective/src/include/perspective/build_filter.h
+++ b/packages/perspective/src/include/perspective/build_filter.h
@@ -80,6 +80,20 @@ apply_filters_helper(const t_table& tbl, const t_str& column, t_mask& mask, t_ts
 
                 tbl, column, mask, values);
         } break;
+        case FILTER_OP_NOT_IN: {
+            std::set<CTYPE_T, t_filter_comparator<CTYPE_T>> values;
+            for (t_uindex fidx = 0, loop_end = filter.m_bag.size();
+
+                 fidx < loop_end; ++fidx) {
+                values.insert(filter
+                                  .m_bag[fidx]
+
+                                  .get<CTYPE_T>());
+            }
+            fop_apply<CTYPE_T, DTYPE_T, t_operator_not_in<CTYPE_T, DTYPE_T>>(
+
+                tbl, column, mask, values);
+        } break;
         default: { PSP_COMPLAIN_AND_ABORT("Unknown filter_op detected"); }
     };
 }

--- a/packages/perspective/src/include/perspective/filter.h
+++ b/packages/perspective/src/include/perspective/filter.h
@@ -64,6 +64,15 @@ struct t_operator_in {
 };
 
 template <typename DATA_T, int DTYPE_T>
+struct t_operator_not_in {
+    inline bool
+    operator()(const DATA_T& value, const std::set<DATA_T>& threshold_values) {
+        return threshold_values.find(value) == threshold_values.end();
+    }
+};
+
+
+template <typename DATA_T, int DTYPE_T>
 struct t_operator_begins_with {
     inline bool
     operator()(DATA_T value, DATA_T threshold_value) {
@@ -142,6 +151,9 @@ struct PERSPECTIVE_EXPORT t_fterm {
     operator()(t_tscalar s) const {
         t_bool rv;
         switch (m_op) {
+            case FILTER_OP_NOT_IN: {
+                rv = std::find(m_bag.begin(), m_bag.end(), s) == m_bag.end();
+            } break;
             case FILTER_OP_IN: {
                 rv = std::find(m_bag.begin(), m_bag.end(), s) != m_bag.end();
             } break;

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1109,6 +1109,7 @@ module.exports = function(Module) {
             "ends with": __MODULE__.t_filter_op.FILTER_OP_ENDS_WITH,
             or: __MODULE__.t_filter_op.FILTER_OP_OR,
             in: __MODULE__.t_filter_op.FILTER_OP_IN,
+            "not in": __MODULE__.t_filter_op.FILTER_OP_NOT_IN,
             and: __MODULE__.t_filter_op.FILTER_OP_AND,
             "is nan": __MODULE__.t_filter_op.FILTER_OP_IS_NAN,
             "is not nan": __MODULE__.t_filter_op.FILTER_OP_IS_NOT_NAN

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -149,6 +149,17 @@ module.exports = perspective => {
             });
         });
 
+        describe("not in", function() {
+            it("y not in ['d']", async function() {
+                var table = perspective.table(data);
+                var view = table.view({
+                    filter: [["y", "not in", ["d"]]]
+                });
+                let json = await view.to_json();
+                expect(rdata.slice(0, 3)).toEqual(json);
+            });
+        });
+
         describe("contains", function() {
             it("y contains 'a'", async function() {
                 var table = perspective.table(data);


### PR DESCRIPTION
For columns with lots of possible string values, 'not in' can be more efficient than an 'in' filter with all the other values.