### PR TITLE
Expose view columns as TypedArrays

### DIFF
--- a/docs/perspective-viewer.md
+++ b/docs/perspective-viewer.md
@@ -54,16 +54,14 @@ names.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('sort', JSON.stringify([["x","desc"]));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer sort='[["x","desc"]]'></perspective-viewer>
@@ -79,16 +77,14 @@ The set of visible columns.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('columns', JSON.stringify(["x", "y'"]));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer columns='["x", "y"]'></perspective-viewer>
@@ -104,16 +100,14 @@ The set of visible columns.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('computed-columns', JSON.stringify([{name: "x+y", func: "add", inputs: ["x", "y"]}]));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer computed-columns="[{name:'x+y',func:'add',inputs:['x','y']}]""></perspective-viewer>
@@ -133,16 +127,14 @@ The set of column aggregate configurations.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('aggregates', JSON.stringify({x: "distinct count"}));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer aggregates='{"x": "distinct count"}'></perspective-viewer>
@@ -154,8 +146,7 @@ The set of column filter configurations.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let filters = [
@@ -166,8 +157,7 @@ let elem = document.getElementById('my_viewer');
 elem.setAttribute('filters', JSON.stringify(filters));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer filters='[["x", "<", 3], ["y", "contains", "abc"]]'></perspective-viewer>
@@ -239,8 +229,7 @@ element, its internal `perspective.table` will also be deleted.
 
 **Examples**
 
-Load JSON
-
+_Load JSON_
 
 ```javascript
 const my_viewer = document.getElementById('#my_viewer');
@@ -250,16 +239,14 @@ my_viewer.load([
 ]);
 ```
 
-Load CSV
-
+_Load CSV_
 
 ```javascript
 const my_viewer = document.getElementById('#my_viewer');
 my_viewer.load("x,y\n1,a\n2,b");
 ```
 
-Load perspective.table
-
+_Load perspective.table_
 
 ```javascript
 const my_viewer = document.getElementById('#my_viewer');

--- a/docs/perspective.md
+++ b/docs/perspective.md
@@ -8,40 +8,41 @@
     -   [to_columns][4]
     -   [to_json][5]
     -   [to_csv][6]
-    -   [num_rows][7]
-    -   [num_columns][8]
-    -   [get_row_expanded][9]
-    -   [expand][10]
-    -   [collapse][11]
-    -   [expand_to_depth][12]
-    -   [collapse_to_depth][13]
-    -   [on_update][14]
-    -   [on_delete][15]
--   [table][16]
-    -   [delete][17]
-    -   [on_delete][18]
-    -   [size][19]
-    -   [schema][20]
-    -   [computed_schema][21]
-    -   [view][22]
-    -   [update][23]
-    -   [remove][24]
-    -   [add_computed][25]
-    -   [columns][26]
-    -   [column_metadata][27]
--   [table][28]
+    -   [col_to_js_typed_array][7]
+    -   [num_rows][8]
+    -   [num_columns][9]
+    -   [get_row_expanded][10]
+    -   [expand][11]
+    -   [collapse][12]
+    -   [expand_to_depth][13]
+    -   [collapse_to_depth][14]
+    -   [on_update][15]
+    -   [on_delete][16]
+-   [table][17]
+    -   [delete][18]
+    -   [on_delete][19]
+    -   [size][20]
+    -   [schema][21]
+    -   [computed_schema][22]
+    -   [view][23]
+    -   [update][24]
+    -   [remove][25]
+    -   [add_computed][26]
+    -   [columns][27]
+    -   [column_metadata][28]
+-   [table][29]
 
 ## view
 
 A View object represents a specific transform (configuration or pivot,
-filter, sort, etc) configuration on an underlying [table][16]. A View
-receives all updates from the [table][16] from which it is derived, and
+filter, sort, etc) configuration on an underlying [table][17]. A View
+receives all updates from the [table][17] from which it is derived, and
 can be serialized to JSON or trigger a callback when it is updated.  View
 objects are immutable, and will remain in memory and actively process
-updates until its [view#delete][29] method is called.
+updates until its [view#delete][30] method is called.
 
 <strong>Note</strong> This constructor is not public - Views are created
-by invoking the [table#view][30] method.
+by invoking the [table#view][31] method.
 
 **Examples**
 
@@ -62,9 +63,9 @@ The schema of this [view][1].  A schema is an Object, the keys of which
 are the columns of this [view][1], and the values are their string type names.
 If this [view][1] is aggregated, theses will be the aggregated types;
 otherwise these types will be the same as the columns in the underlying
-[table][16]
+[table][17]
 
-Returns **[Promise][31]&lt;[Object][32]>** A Promise of this [view][1]'s schema.
+Returns **[Promise][32]&lt;[Object][33]>** A Promise of this [view][1]'s schema.
 
 ### to_columns
 
@@ -72,17 +73,17 @@ Serializes this view to JSON data in a column-oriented format.
 
 **Parameters**
 
--   `options` **[Object][32]?** An optional configuration object.
-    -   `options.start_row` **[number][33]** The starting row index from which
+-   `options` **[Object][33]?** An optional configuration object.
+    -   `options.start_row` **[number][34]** The starting row index from which
         to serialize.
-    -   `options.end_row` **[number][33]** The ending row index from which
+    -   `options.end_row` **[number][34]** The ending row index from which
         to serialize.
-    -   `options.start_col` **[number][33]** The starting column index from which
+    -   `options.start_col` **[number][34]** The starting column index from which
         to serialize.
-    -   `options.end_col` **[number][33]** The ending column index from which
+    -   `options.end_col` **[number][34]** The ending column index from which
         to serialize.
 
-Returns **[Promise][31]&lt;[Array][34]>** A Promise resolving to An array of Objects
+Returns **[Promise][32]&lt;[Array][35]>** A Promise resolving to An array of Objects
 representing the rows of this [view][1].  If this [view][1] had a
 "row_pivots" config parameter supplied when constructed, each row Object
 will have a "**ROW_PATH**" key, whose value specifies this row's
@@ -96,17 +97,17 @@ Serializes this view to JSON data in a row-oriented format.
 
 **Parameters**
 
--   `options` **[Object][32]?** An optional configuration object.
-    -   `options.start_row` **[number][33]** The starting row index from which
+-   `options` **[Object][33]?** An optional configuration object.
+    -   `options.start_row` **[number][34]** The starting row index from which
         to serialize.
-    -   `options.end_row` **[number][33]** The ending row index from which
+    -   `options.end_row` **[number][34]** The ending row index from which
         to serialize.
-    -   `options.start_col` **[number][33]** The starting column index from which
+    -   `options.start_col` **[number][34]** The starting column index from which
         to serialize.
-    -   `options.end_col` **[number][33]** The ending column index from which
+    -   `options.end_col` **[number][34]** The ending column index from which
         to serialize.
 
-Returns **[Promise][31]&lt;[Array][34]>** A Promise resolving to An array of Objects
+Returns **[Promise][32]&lt;[Array][35]>** A Promise resolving to An array of Objects
 representing the rows of this [view][1].  If this [view][1] had a
 "row_pivots" config parameter supplied when constructed, each row Object
 will have a "**ROW_PATH**" key, whose value specifies this row's
@@ -120,19 +121,19 @@ Serializes this view to CSV data in a standard format.
 
 **Parameters**
 
--   `options` **[Object][32]?** An optional configuration object.
-    -   `options.start_row` **[number][33]** The starting row index from which
+-   `options` **[Object][33]?** An optional configuration object.
+    -   `options.start_row` **[number][34]** The starting row index from which
         to serialize.
-    -   `options.end_row` **[number][33]** The ending row index from which
+    -   `options.end_row` **[number][34]** The ending row index from which
         to serialize.
-    -   `options.start_col` **[number][33]** The starting column index from which
+    -   `options.start_col` **[number][34]** The starting column index from which
         to serialize.
-    -   `options.end_col` **[number][33]** The ending column index from which
+    -   `options.end_col` **[number][34]** The ending column index from which
         to serialize.
-    -   `options.config` **[Object][32]** A config object for the Papaparse [https://www.papaparse.com/docs#json-to-csv][35]
+    -   `options.config` **[Object][33]** A config object for the Papaparse [https://www.papaparse.com/docs#json-to-csv][36]
         config object.
 
-Returns **[Promise][31]&lt;[string][36]>** A Promise resolving to a string in CSV format
+Returns **[Promise][32]&lt;[string][37]>** A Promise resolving to a string in CSV format
 representing the rows of this [view][1].  If this [view][1] had a
 "row_pivots" config parameter supplied when constructed, each row
 will have prepended those values specified by this row's
@@ -140,13 +141,30 @@ aggregated path.  If this [view][1] had a "column_pivots" config
 parameter supplied, the keys of this object will be comma-prepended with
 their comma-separated column paths.
 
+### col_to_js_typed_array
+
+Serializes a view column into a TypedArray.
+
+**Parameters**
+
+-   `col_name`  
+-   `column_name` **[string][37]** The name of the column to serialize.
+
+Returns **[Promise][32]&lt;[TypedArray][38]>** A promise resolving to a TypedArray
+representing the data of the column as retrieved from the [view][1] - all
+pivots, aggregates, sorts, and filters have been applied onto the values
+inside the TypedArray. The TypedArray will be constructed based on data type -
+integers will resolve to Int8Array, Int16Array, or Int32Array. Floats resolve to
+Float32Array or Float64Array. If the column cannot be found, or is not of an
+integer/float type, the Promise returns undefined.
+
 ### num_rows
 
 The number of aggregated rows in this [view][1].  This is affected by
 the "row_pivots" configuration parameter supplied to this [view][1]'s
 contructor.
 
-Returns **[Promise][31]&lt;[number][33]>** The number of aggregated rows.
+Returns **[Promise][32]&lt;[number][34]>** The number of aggregated rows.
 
 ### num_columns
 
@@ -154,7 +172,7 @@ The number of aggregated columns in this [view][1].  This is affected by
 the "column_pivots" configuration parameter supplied to this [view][1]'s
 contructor.
 
-Returns **[Promise][31]&lt;[number][33]>** The number of aggregated columns.
+Returns **[Promise][32]&lt;[number][34]>** The number of aggregated columns.
 
 ### get_row_expanded
 
@@ -164,7 +182,7 @@ Whether this row at index `idx` is in an expanded or collapsed state.
 
 -   `idx`  
 
-Returns **[Promise][31]&lt;bool>** Whether this row is expanded.
+Returns **[Promise][32]&lt;bool>** Whether this row is expanded.
 
 ### expand
 
@@ -174,7 +192,7 @@ Expands the row at index `idx`.
 
 -   `idx`  
 
-Returns **[Promise][31]&lt;void>** 
+Returns **[Promise][32]&lt;void>** 
 
 ### collapse
 
@@ -184,7 +202,7 @@ Collapses the row at index `idx`.
 
 -   `idx`  
 
-Returns **[Promise][31]&lt;void>** 
+Returns **[Promise][32]&lt;void>** 
 
 ### expand_to_depth
 
@@ -210,9 +228,9 @@ aggregated row deltas.
 
 **Parameters**
 
--   `callback` **[function][37]** A callback function invoked on update.  The
+-   `callback` **[function][39]** A callback function invoked on update.  The
     parameter to this callback shares a structure with the return type of
-    [view#to_json][38].
+    [view#to_json][40].
 
 ### on_delete
 
@@ -221,9 +239,9 @@ is deleted, this callback will be invoked.
 
 **Parameters**
 
--   `callback` **[function][37]** A callback function invoked on update.  The
+-   `callback` **[function][39]** A callback function invoked on update.  The
         parameter to this callback shares a structure with the return type of
-        [view#to_json][38].
+        [view#to_json][40].
 
 ## table
 
@@ -232,48 +250,48 @@ typed - they have an immutable set of column names, and a known type for
 each.
 
 <strong>Note</strong> This constructor is not public - Tables are created
-by invoking the [table][16] factory method, either on the perspective
-module object, or an a [worker][39] instance.
+by invoking the [table][17] factory method, either on the perspective
+module object, or an a [worker][41] instance.
 
 ### delete
 
-Delete this [table][16] and clean up all resources associated with it.
+Delete this [table][17] and clean up all resources associated with it.
 Table objects do not stop consuming resources or processing updates when
 they are garbage collected - you must call this method to reclaim these.
 
 ### on_delete
 
-Register a callback with this [table][16].  Whenever the [view][1]
+Register a callback with this [table][17].  Whenever the [view][1]
 is deleted, this callback will be invoked.
 
 **Parameters**
 
--   `callback` **[function][37]** A callback function invoked on update.  The
+-   `callback` **[function][39]** A callback function invoked on update.  The
         parameter to this callback shares a structure with the return type of
-        [table#to_json][40].
+        [table#to_json][42].
 
 ### size
 
-The number of accumulated rows in this [table][16].  This is affected by
+The number of accumulated rows in this [table][17].  This is affected by
 the "index" configuration parameter supplied to this [view][1]'s
 contructor - as rows will be overwritten when they share an idnex column.
 
-Returns **[Promise][31]&lt;[number][33]>** The number of accumulated rows.
+Returns **[Promise][32]&lt;[number][34]>** The number of accumulated rows.
 
 ### schema
 
-The schema of this [table][16].  A schema is an Object whose keys are the
-columns of this [table][16], and whose values are their string type names.
+The schema of this [table][17].  A schema is an Object whose keys are the
+columns of this [table][17], and whose values are their string type names.
 
-Returns **[Promise][31]&lt;[Object][32]>** A Promise of this [table][16]'s schema.
+Returns **[Promise][32]&lt;[Object][33]>** A Promise of this [table][17]'s schema.
 
 ### computed_schema
 
-The computed schema of this [table][16]. Returns a schema of only computed
+The computed schema of this [table][17]. Returns a schema of only computed
 columns added by the user, the keys of which are computed columns and the values an
 Object containing the associated column_name, column_type, and computation.
 
-Returns **[Promise][31]&lt;[Object][32]>** A Promise of this [table][16]'s computed schema.
+Returns **[Promise][32]&lt;[Object][33]>** A Promise of this [table][17]'s computed schema.
 
 ### view
 
@@ -282,19 +300,19 @@ configuration.
 
 **Parameters**
 
--   `config` **[Object][32]?** The configuration object for this [view][1].
-    -   `config.row_pivot` **[Array][34]&lt;[string][36]>?** An array of column names
-        to use as [Row Pivots][41].
-    -   `config.column_pivot` **[Array][34]&lt;[string][36]>?** An array of column names
-        to use as [Column Pivots][42].
-    -   `config.aggregate` **[Array][34]&lt;[Object][32]>?** An Array of Aggregate configuration objects,
+-   `config` **[Object][33]?** The configuration object for this [view][1].
+    -   `config.row_pivot` **[Array][35]&lt;[string][37]>?** An array of column names
+        to use as [Row Pivots][43].
+    -   `config.column_pivot` **[Array][35]&lt;[string][37]>?** An array of column names
+        to use as [Column Pivots][44].
+    -   `config.aggregate` **[Array][35]&lt;[Object][33]>?** An Array of Aggregate configuration objects,
         each of which should provide an "name" and "op" property, repsresnting the string
         aggregation type and associated column name, respectively.  Aggregates not provided
         will use their type defaults
-    -   `config.filter` **[Array][34]&lt;[Array][34]&lt;[string][36]>>?** An Array of Filter configurations to
+    -   `config.filter` **[Array][35]&lt;[Array][35]&lt;[string][37]>>?** An Array of Filter configurations to
         apply.  A filter configuration is an array of 3 elements:  A column name,
         a supported filter comparison string (e.g. '===', '>'), and a value to compare.
-    -   `config.sort` **[Array][34]&lt;[string][36]>?** An Array of column names by which to sort.
+    -   `config.sort` **[Array][35]&lt;[string][37]>?** An Array of column names by which to sort.
 
 **Examples**
 
@@ -307,33 +325,33 @@ var view = table.view({
 });
 ```
 
-Returns **[view][43]** A new [view][1] object for the supplied configuration,
+Returns **[view][45]** A new [view][1] object for the supplied configuration,
 bound to this table
 
 ### update
 
--   **See: [table][16]**
+-   **See: [table][17]**
 
-Updates the rows of a [table][16].  Updated rows are pushed down to any
+Updates the rows of a [table][17].  Updated rows are pushed down to any
 derived [view][1] objects.
 
 **Parameters**
 
--   `data` **([Object][32]&lt;[string][36], [Array][34]> | [Array][34]&lt;[Object][32]> | [string][36])** The input data
+-   `data` **([Object][33]&lt;[string][37], [Array][35]> | [Array][35]&lt;[Object][33]> | [string][37])** The input data
     for this table.  The supported input types mirror the constructor options, minus
     the ability to pass a schema (Object&lt;string, string>) as this table has.
     already been constructed, thus its types are set in stone.
 
 ### remove
 
--   **See: [table][16]**
+-   **See: [table][17]**
 
-Removes the rows of a [table][16].  Removed rows are pushed down to any
+Removes the rows of a [table][17].  Removed rows are pushed down to any
 derived [view][1] objects.
 
 **Parameters**
 
--   `data` **[Array][34]&lt;[Object][32]>** An array of primary keys to remove.
+-   `data` **[Array][35]&lt;[Object][33]>** An array of primary keys to remove.
 
 ### add_computed
 
@@ -347,7 +365,7 @@ Create a new table with the addition of new computed columns (defined as javascr
 
 The column names of this table.
 
-Returns **[Array][34]&lt;[string][36]>** An array of column names for this table.
+Returns **[Array][35]&lt;[string][37]>** An array of column names for this table.
 
 ### column_metadata
 
@@ -361,23 +379,23 @@ If the column is computed, the `computed` property is an Object containing:
 
     Otherwise, `computed` is `undefined`.
 
-Returns **[Array][34]&lt;[object][32]>** An array of Objects containing metadata for each column.
+Returns **[Array][35]&lt;[object][33]>** An array of Objects containing metadata for each column.
 
 ## table
 
-A factory method for constructing [table][16]s.
+A factory method for constructing [table][17]s.
 
 **Parameters**
 
--   `data` **([Object][32]&lt;[string][36], [Array][34]> | [Object][32]&lt;[string][36], [string][36]> | [Array][34]&lt;[Object][32]> | [string][36])** The input data
+-   `data` **([Object][33]&lt;[string][37], [Array][35]> | [Object][33]&lt;[string][37], [string][37]> | [Array][35]&lt;[Object][33]> | [string][37])** The input data
         for this table.  When supplied an Object with string values, an empty
         table is returned using this Object as a schema.  When an Object with
         Array values is supplied, a table is returned using this object's
         key/value pairs as name/columns respectively.  When an Array is supplied,
         a table is constructed using this Array's objects as rows.  When
         a string is supplied, the parameter as parsed as a CSV.
--   `options` **[Object][32]?** An optional options dictionary.
-    -   `options.index` **[string][36]** The name of the column in the resulting
+-   `options` **[Object][33]?** An optional options dictionary.
+    -   `options.index` **[string][37]** The name of the column in the resulting
             table to treat as an index.  When updating this table, rows sharing an
             index of a new row will be overwritten. `index` is mutually exclusive
             to `limit`
@@ -398,7 +416,7 @@ var table = perspective.table([{x: 1}, {x: 2}]);
 var table = worker.table([{x: 1}, {x: 2}]);
 ```
 
-Returns **[table][44]** A new [table][16] object.
+Returns **[table][46]** A new [table][17] object.
 
 [1]: #view
 
@@ -412,78 +430,82 @@ Returns **[table][44]** A new [table][16] object.
 
 [6]: #to_csv
 
-[7]: #num_rows
+[7]: #col_to_js_typed_array
 
-[8]: #num_columns
+[8]: #num_rows
 
-[9]: #get_row_expanded
+[9]: #num_columns
 
-[10]: #expand
+[10]: #get_row_expanded
 
-[11]: #collapse
+[11]: #expand
 
-[12]: #expand_to_depth
+[12]: #collapse
 
-[13]: #collapse_to_depth
+[13]: #expand_to_depth
 
-[14]: #on_update
+[14]: #collapse_to_depth
 
-[15]: #on_delete
+[15]: #on_update
 
-[16]: #table
+[16]: #on_delete
 
-[17]: #delete-1
+[17]: #table
 
-[18]: #on_delete-1
+[18]: #delete-1
 
-[19]: #size
+[19]: #on_delete-1
 
-[20]: #schema-1
+[20]: #size
 
-[21]: #computed_schema
+[21]: #schema-1
 
-[22]: #view-1
+[22]: #computed_schema
 
-[23]: #update
+[23]: #view-1
 
-[24]: #remove
+[24]: #update
 
-[25]: #add_computed
+[25]: #remove
 
-[26]: #columns
+[26]: #add_computed
 
-[27]: #column_metadata
+[27]: #columns
 
-[28]: #table-1
+[28]: #column_metadata
 
-[29]: #viewdelete
+[29]: #table-1
 
-[30]: #tableview
+[30]: #viewdelete
 
-[31]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[31]: #tableview
 
-[32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[33]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[33]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[34]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[34]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[35]: https://www.papaparse.com/docs#json-to-csv
+[35]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[36]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[36]: https://www.papaparse.com/docs#json-to-csv
 
-[37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[38]: #viewto_json
+[38]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
-[39]: https://developer.mozilla.org/docs/Web/JavaScript
+[39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[40]: table#to_json
+[40]: #viewto_json
 
-[41]: https://en.wikipedia.org/wiki/Pivot_table#Row_labels
+[41]: https://developer.mozilla.org/docs/Web/JavaScript
 
-[42]: https://en.wikipedia.org/wiki/Pivot_table#Column_labels
+[42]: table#to_json
 
-[43]: #view
+[43]: https://en.wikipedia.org/wiki/Pivot_table#Row_labels
 
-[44]: #table
+[44]: https://en.wikipedia.org/wiki/Pivot_table#Column_labels
+
+[45]: #view
+
+[46]: #table

--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -18,7 +18,7 @@
         "build:cjs": "webpack --color --config src/config/highcharts.plugin.cjs.config.js",
         "build": "npm-run-all build:*",
         "test:build": "cp test/html/* build",
-        "watch": "webpack --color --config --watch test/config/highcharts.plugin.config.js",
+        "watch": "webpack --color --watch --config src/config/highcharts.plugin.config.js",
         "test:run": "jest --silent --color 2>&1",
         "test": "npm-run-all test:build test:run",
         "clean": "find build -mindepth 1 -delete",

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -18,6 +18,7 @@ import {set_boost, set_category_axis, set_both_axis, default_config, set_tick_si
 
 export const draw = mode =>
     async function(el, view, task) {
+        console.log(view.col_to_typed_array());
         const row_pivots = this._view_columns("#row_pivots perspective-row:not(.off)");
         const col_pivots = this._view_columns("#column_pivots perspective-row:not(.off)");
         const aggregates = this._get_view_aggregates();

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -24,10 +24,6 @@ export const draw = mode =>
         const hidden = this._get_view_hidden(aggregates);
 
         const [schema, tschema] = await Promise.all([view.schema(), this._table.schema()]);
-        for (let key in schema) {
-            console.log(view.col_to_js_typed_array(key));
-        }
-
         let js;
 
         if (task.cancelled) {

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -18,13 +18,15 @@ import {set_boost, set_category_axis, set_both_axis, default_config, set_tick_si
 
 export const draw = mode =>
     async function(el, view, task) {
-        console.log(view.col_to_typed_array());
         const row_pivots = this._view_columns("#row_pivots perspective-row:not(.off)");
         const col_pivots = this._view_columns("#column_pivots perspective-row:not(.off)");
         const aggregates = this._get_view_aggregates();
         const hidden = this._get_view_hidden(aggregates);
 
         const [schema, tschema] = await Promise.all([view.schema(), this._table.schema()]);
+        for (let key in schema) {
+            console.log(view.col_to_js_typed_array(key));
+        }
 
         let js;
 

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -24,7 +24,7 @@ const TEMPLATE = require("../html/hypergrid.html");
 import "../less/hypergrid.less";
 
 const COLUMN_HEADER_FONT = "12px amplitude-regular, Helvetica, sans-serif";
-const GROUP_LABEL_FONT = "12px open sans, sans-serif"; // overrides COLUMN_HEADER_FONT for group labels
+const GROUP_LABEL_FONT = "12px Open Sans, sans-serif"; // overrides COLUMN_HEADER_FONT for group labels
 
 const base_grid_properties = {
     autoSelectRows: false,

--- a/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
+++ b/packages/perspective-viewer-hypergrid/src/less/hypergrid.less
@@ -12,7 +12,7 @@ perspective-hypergrid {
     color: #666;
 
     table {
-        font: 12px "open sans", helvetica, sans-serif;
+        font: 12px "Open Sans", helvetica, sans-serif;
     }
 
     td.hover {

--- a/packages/perspective-viewer/README.md
+++ b/packages/perspective-viewer/README.md
@@ -54,16 +54,14 @@ names.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('sort', JSON.stringify([["x","desc"]));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer sort='[["x","desc"]]'></perspective-viewer>
@@ -79,16 +77,14 @@ The set of visible columns.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('columns', JSON.stringify(["x", "y'"]));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer columns='["x", "y"]'></perspective-viewer>
@@ -104,16 +100,14 @@ The set of visible columns.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('computed-columns', JSON.stringify([{name: "x+y", func: "add", inputs: ["x", "y"]}]));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer computed-columns="[{name:'x+y',func:'add',inputs:['x','y']}]""></perspective-viewer>
@@ -133,16 +127,14 @@ The set of column aggregate configurations.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let elem = document.getElementById('my_viewer');
 elem.setAttribute('aggregates', JSON.stringify({x: "distinct count"}));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer aggregates='{"x": "distinct count"}'></perspective-viewer>
@@ -154,8 +146,7 @@ The set of column filter configurations.
 
 **Examples**
 
-via Javascript DOM
-
+_via Javascript DOM_
 
 ```javascript
 let filters = [
@@ -166,8 +157,7 @@ let elem = document.getElementById('my_viewer');
 elem.setAttribute('filters', JSON.stringify(filters));
 ```
 
-via HTML
-
+_via HTML_
 
 ```javascript
 <perspective-viewer filters='[["x", "<", 3], ["y", "contains", "abc"]]'></perspective-viewer>
@@ -239,8 +229,7 @@ element, its internal `perspective.table` will also be deleted.
 
 **Examples**
 
-Load JSON
-
+_Load JSON_
 
 ```javascript
 const my_viewer = document.getElementById('#my_viewer');
@@ -250,16 +239,14 @@ my_viewer.load([
 ]);
 ```
 
-Load CSV
-
+_Load CSV_
 
 ```javascript
 const my_viewer = document.getElementById('#my_viewer');
 my_viewer.load("x,y\n1,a\n2,b");
 ```
 
-Load perspective.table
-
+_Load perspective.table_
 
 ```javascript
 const my_viewer = document.getElementById('#my_viewer');

--- a/packages/perspective/README.md
+++ b/packages/perspective/README.md
@@ -8,40 +8,41 @@
     -   [to_columns][4]
     -   [to_json][5]
     -   [to_csv][6]
-    -   [num_rows][7]
-    -   [num_columns][8]
-    -   [get_row_expanded][9]
-    -   [expand][10]
-    -   [collapse][11]
-    -   [expand_to_depth][12]
-    -   [collapse_to_depth][13]
-    -   [on_update][14]
-    -   [on_delete][15]
--   [table][16]
-    -   [delete][17]
-    -   [on_delete][18]
-    -   [size][19]
-    -   [schema][20]
-    -   [computed_schema][21]
-    -   [view][22]
-    -   [update][23]
-    -   [remove][24]
-    -   [add_computed][25]
-    -   [columns][26]
-    -   [column_metadata][27]
--   [table][28]
+    -   [col_to_js_typed_array][7]
+    -   [num_rows][8]
+    -   [num_columns][9]
+    -   [get_row_expanded][10]
+    -   [expand][11]
+    -   [collapse][12]
+    -   [expand_to_depth][13]
+    -   [collapse_to_depth][14]
+    -   [on_update][15]
+    -   [on_delete][16]
+-   [table][17]
+    -   [delete][18]
+    -   [on_delete][19]
+    -   [size][20]
+    -   [schema][21]
+    -   [computed_schema][22]
+    -   [view][23]
+    -   [update][24]
+    -   [remove][25]
+    -   [add_computed][26]
+    -   [columns][27]
+    -   [column_metadata][28]
+-   [table][29]
 
 ## view
 
 A View object represents a specific transform (configuration or pivot,
-filter, sort, etc) configuration on an underlying [table][16]. A View
-receives all updates from the [table][16] from which it is derived, and
+filter, sort, etc) configuration on an underlying [table][17]. A View
+receives all updates from the [table][17] from which it is derived, and
 can be serialized to JSON or trigger a callback when it is updated.  View
 objects are immutable, and will remain in memory and actively process
-updates until its [view#delete][29] method is called.
+updates until its [view#delete][30] method is called.
 
 <strong>Note</strong> This constructor is not public - Views are created
-by invoking the [table#view][30] method.
+by invoking the [table#view][31] method.
 
 **Examples**
 
@@ -62,9 +63,9 @@ The schema of this [view][1].  A schema is an Object, the keys of which
 are the columns of this [view][1], and the values are their string type names.
 If this [view][1] is aggregated, theses will be the aggregated types;
 otherwise these types will be the same as the columns in the underlying
-[table][16]
+[table][17]
 
-Returns **[Promise][31]&lt;[Object][32]>** A Promise of this [view][1]'s schema.
+Returns **[Promise][32]&lt;[Object][33]>** A Promise of this [view][1]'s schema.
 
 ### to_columns
 
@@ -72,17 +73,17 @@ Serializes this view to JSON data in a column-oriented format.
 
 **Parameters**
 
--   `options` **[Object][32]?** An optional configuration object.
-    -   `options.start_row` **[number][33]** The starting row index from which
+-   `options` **[Object][33]?** An optional configuration object.
+    -   `options.start_row` **[number][34]** The starting row index from which
         to serialize.
-    -   `options.end_row` **[number][33]** The ending row index from which
+    -   `options.end_row` **[number][34]** The ending row index from which
         to serialize.
-    -   `options.start_col` **[number][33]** The starting column index from which
+    -   `options.start_col` **[number][34]** The starting column index from which
         to serialize.
-    -   `options.end_col` **[number][33]** The ending column index from which
+    -   `options.end_col` **[number][34]** The ending column index from which
         to serialize.
 
-Returns **[Promise][31]&lt;[Array][34]>** A Promise resolving to An array of Objects
+Returns **[Promise][32]&lt;[Array][35]>** A Promise resolving to An array of Objects
 representing the rows of this [view][1].  If this [view][1] had a
 "row_pivots" config parameter supplied when constructed, each row Object
 will have a "**ROW_PATH**" key, whose value specifies this row's
@@ -96,17 +97,17 @@ Serializes this view to JSON data in a row-oriented format.
 
 **Parameters**
 
--   `options` **[Object][32]?** An optional configuration object.
-    -   `options.start_row` **[number][33]** The starting row index from which
+-   `options` **[Object][33]?** An optional configuration object.
+    -   `options.start_row` **[number][34]** The starting row index from which
         to serialize.
-    -   `options.end_row` **[number][33]** The ending row index from which
+    -   `options.end_row` **[number][34]** The ending row index from which
         to serialize.
-    -   `options.start_col` **[number][33]** The starting column index from which
+    -   `options.start_col` **[number][34]** The starting column index from which
         to serialize.
-    -   `options.end_col` **[number][33]** The ending column index from which
+    -   `options.end_col` **[number][34]** The ending column index from which
         to serialize.
 
-Returns **[Promise][31]&lt;[Array][34]>** A Promise resolving to An array of Objects
+Returns **[Promise][32]&lt;[Array][35]>** A Promise resolving to An array of Objects
 representing the rows of this [view][1].  If this [view][1] had a
 "row_pivots" config parameter supplied when constructed, each row Object
 will have a "**ROW_PATH**" key, whose value specifies this row's
@@ -120,19 +121,19 @@ Serializes this view to CSV data in a standard format.
 
 **Parameters**
 
--   `options` **[Object][32]?** An optional configuration object.
-    -   `options.start_row` **[number][33]** The starting row index from which
+-   `options` **[Object][33]?** An optional configuration object.
+    -   `options.start_row` **[number][34]** The starting row index from which
         to serialize.
-    -   `options.end_row` **[number][33]** The ending row index from which
+    -   `options.end_row` **[number][34]** The ending row index from which
         to serialize.
-    -   `options.start_col` **[number][33]** The starting column index from which
+    -   `options.start_col` **[number][34]** The starting column index from which
         to serialize.
-    -   `options.end_col` **[number][33]** The ending column index from which
+    -   `options.end_col` **[number][34]** The ending column index from which
         to serialize.
-    -   `options.config` **[Object][32]** A config object for the Papaparse [https://www.papaparse.com/docs#json-to-csv][35]
+    -   `options.config` **[Object][33]** A config object for the Papaparse [https://www.papaparse.com/docs#json-to-csv][36]
         config object.
 
-Returns **[Promise][31]&lt;[string][36]>** A Promise resolving to a string in CSV format
+Returns **[Promise][32]&lt;[string][37]>** A Promise resolving to a string in CSV format
 representing the rows of this [view][1].  If this [view][1] had a
 "row_pivots" config parameter supplied when constructed, each row
 will have prepended those values specified by this row's
@@ -140,13 +141,30 @@ aggregated path.  If this [view][1] had a "column_pivots" config
 parameter supplied, the keys of this object will be comma-prepended with
 their comma-separated column paths.
 
+### col_to_js_typed_array
+
+Serializes a view column into a TypedArray.
+
+**Parameters**
+
+-   `col_name`  
+-   `column_name` **[string][37]** The name of the column to serialize.
+
+Returns **[Promise][32]&lt;[TypedArray][38]>** A promise resolving to a TypedArray
+representing the data of the column as retrieved from the [view][1] - all
+pivots, aggregates, sorts, and filters have been applied onto the values
+inside the TypedArray. The TypedArray will be constructed based on data type -
+integers will resolve to Int8Array, Int16Array, or Int32Array. Floats resolve to
+Float32Array or Float64Array. If the column cannot be found, or is not of an
+integer/float type, the Promise returns undefined.
+
 ### num_rows
 
 The number of aggregated rows in this [view][1].  This is affected by
 the "row_pivots" configuration parameter supplied to this [view][1]'s
 contructor.
 
-Returns **[Promise][31]&lt;[number][33]>** The number of aggregated rows.
+Returns **[Promise][32]&lt;[number][34]>** The number of aggregated rows.
 
 ### num_columns
 
@@ -154,7 +172,7 @@ The number of aggregated columns in this [view][1].  This is affected by
 the "column_pivots" configuration parameter supplied to this [view][1]'s
 contructor.
 
-Returns **[Promise][31]&lt;[number][33]>** The number of aggregated columns.
+Returns **[Promise][32]&lt;[number][34]>** The number of aggregated columns.
 
 ### get_row_expanded
 
@@ -164,7 +182,7 @@ Whether this row at index `idx` is in an expanded or collapsed state.
 
 -   `idx`  
 
-Returns **[Promise][31]&lt;bool>** Whether this row is expanded.
+Returns **[Promise][32]&lt;bool>** Whether this row is expanded.
 
 ### expand
 
@@ -174,7 +192,7 @@ Expands the row at index `idx`.
 
 -   `idx`  
 
-Returns **[Promise][31]&lt;void>** 
+Returns **[Promise][32]&lt;void>** 
 
 ### collapse
 
@@ -184,7 +202,7 @@ Collapses the row at index `idx`.
 
 -   `idx`  
 
-Returns **[Promise][31]&lt;void>** 
+Returns **[Promise][32]&lt;void>** 
 
 ### expand_to_depth
 
@@ -210,9 +228,9 @@ aggregated row deltas.
 
 **Parameters**
 
--   `callback` **[function][37]** A callback function invoked on update.  The
+-   `callback` **[function][39]** A callback function invoked on update.  The
     parameter to this callback shares a structure with the return type of
-    [view#to_json][38].
+    [view#to_json][40].
 
 ### on_delete
 
@@ -221,9 +239,9 @@ is deleted, this callback will be invoked.
 
 **Parameters**
 
--   `callback` **[function][37]** A callback function invoked on update.  The
+-   `callback` **[function][39]** A callback function invoked on update.  The
         parameter to this callback shares a structure with the return type of
-        [view#to_json][38].
+        [view#to_json][40].
 
 ## table
 
@@ -232,48 +250,48 @@ typed - they have an immutable set of column names, and a known type for
 each.
 
 <strong>Note</strong> This constructor is not public - Tables are created
-by invoking the [table][16] factory method, either on the perspective
-module object, or an a [worker][39] instance.
+by invoking the [table][17] factory method, either on the perspective
+module object, or an a [worker][41] instance.
 
 ### delete
 
-Delete this [table][16] and clean up all resources associated with it.
+Delete this [table][17] and clean up all resources associated with it.
 Table objects do not stop consuming resources or processing updates when
 they are garbage collected - you must call this method to reclaim these.
 
 ### on_delete
 
-Register a callback with this [table][16].  Whenever the [view][1]
+Register a callback with this [table][17].  Whenever the [view][1]
 is deleted, this callback will be invoked.
 
 **Parameters**
 
--   `callback` **[function][37]** A callback function invoked on update.  The
+-   `callback` **[function][39]** A callback function invoked on update.  The
         parameter to this callback shares a structure with the return type of
-        [table#to_json][40].
+        [table#to_json][42].
 
 ### size
 
-The number of accumulated rows in this [table][16].  This is affected by
+The number of accumulated rows in this [table][17].  This is affected by
 the "index" configuration parameter supplied to this [view][1]'s
 contructor - as rows will be overwritten when they share an idnex column.
 
-Returns **[Promise][31]&lt;[number][33]>** The number of accumulated rows.
+Returns **[Promise][32]&lt;[number][34]>** The number of accumulated rows.
 
 ### schema
 
-The schema of this [table][16].  A schema is an Object whose keys are the
-columns of this [table][16], and whose values are their string type names.
+The schema of this [table][17].  A schema is an Object whose keys are the
+columns of this [table][17], and whose values are their string type names.
 
-Returns **[Promise][31]&lt;[Object][32]>** A Promise of this [table][16]'s schema.
+Returns **[Promise][32]&lt;[Object][33]>** A Promise of this [table][17]'s schema.
 
 ### computed_schema
 
-The computed schema of this [table][16]. Returns a schema of only computed
+The computed schema of this [table][17]. Returns a schema of only computed
 columns added by the user, the keys of which are computed columns and the values an
 Object containing the associated column_name, column_type, and computation.
 
-Returns **[Promise][31]&lt;[Object][32]>** A Promise of this [table][16]'s computed schema.
+Returns **[Promise][32]&lt;[Object][33]>** A Promise of this [table][17]'s computed schema.
 
 ### view
 
@@ -282,19 +300,19 @@ configuration.
 
 **Parameters**
 
--   `config` **[Object][32]?** The configuration object for this [view][1].
-    -   `config.row_pivot` **[Array][34]&lt;[string][36]>?** An array of column names
-        to use as [Row Pivots][41].
-    -   `config.column_pivot` **[Array][34]&lt;[string][36]>?** An array of column names
-        to use as [Column Pivots][42].
-    -   `config.aggregate` **[Array][34]&lt;[Object][32]>?** An Array of Aggregate configuration objects,
+-   `config` **[Object][33]?** The configuration object for this [view][1].
+    -   `config.row_pivot` **[Array][35]&lt;[string][37]>?** An array of column names
+        to use as [Row Pivots][43].
+    -   `config.column_pivot` **[Array][35]&lt;[string][37]>?** An array of column names
+        to use as [Column Pivots][44].
+    -   `config.aggregate` **[Array][35]&lt;[Object][33]>?** An Array of Aggregate configuration objects,
         each of which should provide an "name" and "op" property, repsresnting the string
         aggregation type and associated column name, respectively.  Aggregates not provided
         will use their type defaults
-    -   `config.filter` **[Array][34]&lt;[Array][34]&lt;[string][36]>>?** An Array of Filter configurations to
+    -   `config.filter` **[Array][35]&lt;[Array][35]&lt;[string][37]>>?** An Array of Filter configurations to
         apply.  A filter configuration is an array of 3 elements:  A column name,
         a supported filter comparison string (e.g. '===', '>'), and a value to compare.
-    -   `config.sort` **[Array][34]&lt;[string][36]>?** An Array of column names by which to sort.
+    -   `config.sort` **[Array][35]&lt;[string][37]>?** An Array of column names by which to sort.
 
 **Examples**
 
@@ -307,33 +325,33 @@ var view = table.view({
 });
 ```
 
-Returns **[view][43]** A new [view][1] object for the supplied configuration,
+Returns **[view][45]** A new [view][1] object for the supplied configuration,
 bound to this table
 
 ### update
 
--   **See: [table][16]**
+-   **See: [table][17]**
 
-Updates the rows of a [table][16].  Updated rows are pushed down to any
+Updates the rows of a [table][17].  Updated rows are pushed down to any
 derived [view][1] objects.
 
 **Parameters**
 
--   `data` **([Object][32]&lt;[string][36], [Array][34]> | [Array][34]&lt;[Object][32]> | [string][36])** The input data
+-   `data` **([Object][33]&lt;[string][37], [Array][35]> | [Array][35]&lt;[Object][33]> | [string][37])** The input data
     for this table.  The supported input types mirror the constructor options, minus
     the ability to pass a schema (Object&lt;string, string>) as this table has.
     already been constructed, thus its types are set in stone.
 
 ### remove
 
--   **See: [table][16]**
+-   **See: [table][17]**
 
-Removes the rows of a [table][16].  Removed rows are pushed down to any
+Removes the rows of a [table][17].  Removed rows are pushed down to any
 derived [view][1] objects.
 
 **Parameters**
 
--   `data` **[Array][34]&lt;[Object][32]>** An array of primary keys to remove.
+-   `data` **[Array][35]&lt;[Object][33]>** An array of primary keys to remove.
 
 ### add_computed
 
@@ -347,7 +365,7 @@ Create a new table with the addition of new computed columns (defined as javascr
 
 The column names of this table.
 
-Returns **[Array][34]&lt;[string][36]>** An array of column names for this table.
+Returns **[Array][35]&lt;[string][37]>** An array of column names for this table.
 
 ### column_metadata
 
@@ -361,23 +379,23 @@ If the column is computed, the `computed` property is an Object containing:
 
     Otherwise, `computed` is `undefined`.
 
-Returns **[Array][34]&lt;[object][32]>** An array of Objects containing metadata for each column.
+Returns **[Array][35]&lt;[object][33]>** An array of Objects containing metadata for each column.
 
 ## table
 
-A factory method for constructing [table][16]s.
+A factory method for constructing [table][17]s.
 
 **Parameters**
 
--   `data` **([Object][32]&lt;[string][36], [Array][34]> | [Object][32]&lt;[string][36], [string][36]> | [Array][34]&lt;[Object][32]> | [string][36])** The input data
+-   `data` **([Object][33]&lt;[string][37], [Array][35]> | [Object][33]&lt;[string][37], [string][37]> | [Array][35]&lt;[Object][33]> | [string][37])** The input data
         for this table.  When supplied an Object with string values, an empty
         table is returned using this Object as a schema.  When an Object with
         Array values is supplied, a table is returned using this object's
         key/value pairs as name/columns respectively.  When an Array is supplied,
         a table is constructed using this Array's objects as rows.  When
         a string is supplied, the parameter as parsed as a CSV.
--   `options` **[Object][32]?** An optional options dictionary.
-    -   `options.index` **[string][36]** The name of the column in the resulting
+-   `options` **[Object][33]?** An optional options dictionary.
+    -   `options.index` **[string][37]** The name of the column in the resulting
             table to treat as an index.  When updating this table, rows sharing an
             index of a new row will be overwritten. `index` is mutually exclusive
             to `limit`
@@ -398,7 +416,7 @@ var table = perspective.table([{x: 1}, {x: 2}]);
 var table = worker.table([{x: 1}, {x: 2}]);
 ```
 
-Returns **[table][44]** A new [table][16] object.
+Returns **[table][46]** A new [table][17] object.
 
 [1]: #view
 
@@ -412,78 +430,82 @@ Returns **[table][44]** A new [table][16] object.
 
 [6]: #to_csv
 
-[7]: #num_rows
+[7]: #col_to_js_typed_array
 
-[8]: #num_columns
+[8]: #num_rows
 
-[9]: #get_row_expanded
+[9]: #num_columns
 
-[10]: #expand
+[10]: #get_row_expanded
 
-[11]: #collapse
+[11]: #expand
 
-[12]: #expand_to_depth
+[12]: #collapse
 
-[13]: #collapse_to_depth
+[13]: #expand_to_depth
 
-[14]: #on_update
+[14]: #collapse_to_depth
 
-[15]: #on_delete
+[15]: #on_update
 
-[16]: #table
+[16]: #on_delete
 
-[17]: #delete-1
+[17]: #table
 
-[18]: #on_delete-1
+[18]: #delete-1
 
-[19]: #size
+[19]: #on_delete-1
 
-[20]: #schema-1
+[20]: #size
 
-[21]: #computed_schema
+[21]: #schema-1
 
-[22]: #view-1
+[22]: #computed_schema
 
-[23]: #update
+[23]: #view-1
 
-[24]: #remove
+[24]: #update
 
-[25]: #add_computed
+[25]: #remove
 
-[26]: #columns
+[26]: #add_computed
 
-[27]: #column_metadata
+[27]: #columns
 
-[28]: #table-1
+[28]: #column_metadata
 
-[29]: #viewdelete
+[29]: #table-1
 
-[30]: #tableview
+[30]: #viewdelete
 
-[31]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[31]: #tableview
 
-[32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[33]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[33]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[34]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[34]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[35]: https://www.papaparse.com/docs#json-to-csv
+[35]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[36]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[36]: https://www.papaparse.com/docs#json-to-csv
 
-[37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[38]: #viewto_json
+[38]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
-[39]: https://developer.mozilla.org/docs/Web/JavaScript
+[39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[40]: table#to_json
+[40]: #viewto_json
 
-[41]: https://en.wikipedia.org/wiki/Pivot_table#Row_labels
+[41]: https://developer.mozilla.org/docs/Web/JavaScript
 
-[42]: https://en.wikipedia.org/wiki/Pivot_table#Column_labels
+[42]: table#to_json
 
-[43]: #view
+[43]: https://en.wikipedia.org/wiki/Pivot_table#Row_labels
 
-[44]: #table
+[44]: https://en.wikipedia.org/wiki/Pivot_table#Column_labels
+
+[45]: #view
+
+[46]: #table

--- a/packages/perspective/src/js/api.js
+++ b/packages/perspective/src/js/api.js
@@ -79,6 +79,8 @@ view.prototype.collapse = async_queue("collapse");
 
 view.prototype.delete = async_queue("delete");
 
+view.prototype.col_to_typed_array = async_queue("col_to_typed_array");
+
 view.prototype.on_update = subscribe("on_update", "view_method", true);
 
 view.prototype.on_delete = subscribe("on_delete", "view_method", true);

--- a/packages/perspective/src/js/api.js
+++ b/packages/perspective/src/js/api.js
@@ -79,7 +79,7 @@ view.prototype.collapse = async_queue("collapse");
 
 view.prototype.delete = async_queue("delete");
 
-view.prototype.col_to_typed_array = async_queue("col_to_typed_array");
+view.prototype.col_to_js_typed_array = async_queue("col_to_js_typed_array");
 
 view.prototype.on_update = subscribe("on_update", "view_method", true);
 

--- a/packages/perspective/src/js/defaults.js
+++ b/packages/perspective/src/js/defaults.js
@@ -80,3 +80,9 @@ export const FILTER_DEFAULTS = {
     datetime: "==",
     date: "=="
 };
+
+export const TYPED_ARRAY_SENTINEL_VALUE_INT8 = 255;
+export const TYPED_ARRAY_SENTINEL_VALUE_INT16 = 32767;
+export const TYPED_ARRAY_SENTINEL_VALUE_INT32 = 2147483647;
+export const TYPED_ARRAY_SENTINEL_VALUE_FLOAT32 = 3.40282e38;
+export const TYPED_ARRAY_SENTINEL_VALUE_FLOAT64 = Number.MAX_VALUE;

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -864,49 +864,23 @@ module.exports = function(Module) {
         this._delete_callback = callback;
     };
 
-    view.prototype.col_to_typed_array = async function() {
-        // TODO: implement name-to-index matching
-        /* const schema = await this.schema();
-
-        if (schema[col_name] !== "float" || schema[col_name] !== "integer") {
-            return null;
+    view.prototype.col_to_js_typed_array = async function(col_name) {
+        // TODO: does not yet work with col pivots
+        const [names, schema] = await Promise.all([this._column_names(), this.schema()]);
+        let idx = names.indexOf(col_name);
+        if (idx === -1 || (schema[col_name] !== "float" && schema[col_name] !== "integer")) {
+            return undefined;
         }
-        */
-        let arrs = [];
 
         if (this.sides() === 0) {
-            for (let i = 0; i < 100; i++) {
-                let ta = __MODULE__.col_to_typed_array_zero(this.ctx, i);
-                if (ta !== undefined) {
-                    arrs.push({
-                        index: i,
-                        data: ta
-                    });
-                }
-            }
+            return __MODULE__.col_to_js_typed_array_zero(this.ctx, idx);
         } else if (this.sides() === 1) {
-            for (let i = 0; i < 100; i++) {
-                let ta = __MODULE__.col_to_typed_array_one(this.ctx, i);
-                if (ta !== undefined) {
-                    arrs.push({
-                        index: i,
-                        data: ta
-                    });
-                }
-            }
+            // column at idx 0 is invalid, increment to avoid
+            idx += 1;
+            return __MODULE__.col_to_js_typed_array_one(this.ctx, idx);
         } else {
-            for (let i = 0; i < 100; i++) {
-                let ta = __MODULE__.col_to_typed_array_two(this.ctx, i);
-                if (ta !== undefined) {
-                    arrs.push({
-                        index: i,
-                        data: ta
-                    });
-                }
-            }
+            return __MODULE__.col_to_js_typed_array_two(this.ctx, idx);
         }
-
-        return arrs;
     };
 
     /******************************************************************************

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -864,6 +864,51 @@ module.exports = function(Module) {
         this._delete_callback = callback;
     };
 
+    view.prototype.col_to_typed_array = async function() {
+        // TODO: implement name-to-index matching
+        /* const schema = await this.schema();
+
+        if (schema[col_name] !== "float" || schema[col_name] !== "integer") {
+            return null;
+        }
+        */
+        let arrs = [];
+
+        if (this.sides() === 0) {
+            for (let i = 0; i < 100; i++) {
+                let ta = __MODULE__.col_to_typed_array_zero(this.ctx, i);
+                if (ta !== undefined) {
+                    arrs.push({
+                        index: i,
+                        data: ta
+                    });
+                }
+            }
+        } else if (this.sides() === 1) {
+            for (let i = 0; i < 100; i++) {
+                let ta = __MODULE__.col_to_typed_array_one(this.ctx, i);
+                if (ta !== undefined) {
+                    arrs.push({
+                        index: i,
+                        data: ta
+                    });
+                }
+            }
+        } else {
+            for (let i = 0; i < 100; i++) {
+                let ta = __MODULE__.col_to_typed_array_two(this.ctx, i);
+                if (ta !== undefined) {
+                    arrs.push({
+                        index: i,
+                        data: ta
+                    });
+                }
+            }
+        }
+
+        return arrs;
+    };
+
     /******************************************************************************
      *
      * Table

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1859,6 +1859,9 @@ module.exports = function(Module) {
                     pool.process();
                 }
 
+                // TODO: remove this part
+                // __MODULE__.col_to_arraybuffer(tbl, "")
+
                 return new table(gnode, pool, options.index, undefined, options.limit, limit_index);
             } catch (e) {
                 if (pool) {

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -730,6 +730,48 @@ module.exports = function(Module) {
     };
 
     /**
+     * Serializes a view column into a TypedArray.
+     *
+     * @async
+     *
+     * @param {string} column_name The name of the column to serialize.
+     *
+     * @returns {Promise<TypedArray>} A promise resolving to a TypedArray
+     * representing the data of the column as retrieved from the {@link view} - all
+     * pivots, aggregates, sorts, and filters have been applied onto the values
+     * inside the TypedArray. The TypedArray will be constructed based on data type -
+     * integers will resolve to Int8Array, Int16Array, or Int32Array. Floats resolve to
+     * Float32Array or Float64Array. If the column cannot be found, or is not of an
+     * integer/float type, the Promise returns undefined.
+     */
+    view.prototype.col_to_js_typed_array = async function(col_name) {
+        const names = await this._column_names();
+        let idx = names.indexOf(col_name);
+
+        // type-checking is handled in c++ to accomodate column-pivoted views
+        if (idx === -1) {
+            return undefined;
+        }
+
+        if (this.sides() === 0) {
+            return __MODULE__.col_to_js_typed_array_zero(this.ctx, idx);
+        } else if (this.sides() === 1) {
+            // columns start at 1 for > 0-sided views
+            return __MODULE__.col_to_js_typed_array_one(this.ctx, idx + 1);
+        } else {
+            const column_pivot_only = this.config.row_pivot[0] === "psp_okey" || this.config.column_only === true;
+            let arr = __MODULE__.col_to_js_typed_array_two(this.ctx, idx + 1);
+            if (arr !== undefined) {
+                if (column_pivot_only) {
+                    // remove agg of psp_okey
+                    arr = arr.subarray(1, arr.length);
+                }
+            }
+            return arr;
+        }
+    };
+
+    /**
      * The number of aggregated rows in this {@link view}.  This is affected by
      * the "row_pivots" configuration parameter supplied to this {@link view}'s
      * contructor.
@@ -862,25 +904,6 @@ module.exports = function(Module) {
      */
     view.prototype.on_delete = function(callback) {
         this._delete_callback = callback;
-    };
-
-    view.prototype.col_to_js_typed_array = async function(col_name) {
-        // TODO: does not yet work with col pivots
-        const [names, schema] = await Promise.all([this._column_names(), this.schema()]);
-        let idx = names.indexOf(col_name);
-        if (idx === -1 || (schema[col_name] !== "float" && schema[col_name] !== "integer")) {
-            return undefined;
-        }
-
-        if (this.sides() === 0) {
-            return __MODULE__.col_to_js_typed_array_zero(this.ctx, idx);
-        } else if (this.sides() === 1) {
-            // column at idx 0 is invalid, increment to avoid
-            idx += 1;
-            return __MODULE__.col_to_js_typed_array_one(this.ctx, idx);
-        } else {
-            return __MODULE__.col_to_js_typed_array_two(this.ctx, idx);
-        }
     };
 
     /******************************************************************************

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1859,9 +1859,6 @@ module.exports = function(Module) {
                     pool.process();
                 }
 
-                // TODO: remove this part
-                // __MODULE__.col_to_arraybuffer(tbl, "")
-
                 return new table(gnode, pool, options.index, undefined, options.limit, limit_index);
             } catch (e) {
                 if (pool) {

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -131,6 +131,8 @@ var csv = "x,y,z\n1,a,true\n2,b,false\n3,c,true\n4,d,false";
 
 var data_6 = [{x: "š"}];
 
+var int_float_data = [{int: 1, float: 2.25}, {int: 2, float: 3.5}, {int: 3, float: 4.75}, {int: 4, float: 5.25}];
+
 module.exports = perspective => {
     describe("Execute", function() {
         it("serialized functions in a worker", async function() {
@@ -170,6 +172,43 @@ module.exports = perspective => {
             await view2.delete();
             await table.delete();
             expect(true).toEqual(true);
+        });
+    });
+
+    describe("Typed Arrays", function() {
+        it("Ints to TypedArray in 0-sided view", async function() {
+            var table = perspective.table(int_float_data);
+            var view = table.view();
+            const result = await view.col_to_js_typed_array("int");
+            expect(result.byteLength).toEqual(16);
+        });
+
+        it("Floats to TypedArray in 0-sided view", async function() {
+            var table = perspective.table(int_float_data);
+            var view = table.view();
+            const result = await view.col_to_js_typed_array("float");
+            expect(result.byteLength).toEqual(32);
+        });
+
+        it("Ints to TypedArray in 1-sided view", async function() {
+            var table = perspective.table(int_float_data);
+            var view = table.view({
+                row_pivot: ["int"],
+                aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
+            });
+            const result = await view.col_to_js_typed_array("int");
+            // should include aggregate row
+            expect(result.byteLength).toEqual(20);
+        });
+
+        it("Floats to TypedArray in 1-sided view", async function() {
+            var table = perspective.table(int_float_data);
+            var view = table.view({
+                row_pivot: ["int"],
+                aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
+            });
+            const result = await view.col_to_js_typed_array("float");
+            expect(result.byteLength).toEqual(40);
         });
     });
 

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -132,6 +132,7 @@ var csv = "x,y,z\n1,a,true\n2,b,false\n3,c,true\n4,d,false";
 var data_6 = [{x: "š"}];
 
 var int_float_data = [{int: 1, float: 2.25}, {int: 2, float: 3.5}, {int: 3, float: 4.75}, {int: 4, float: 5.25}];
+var int_float_string_data = [{int: 1, float: 2.25, string: "a"}, {int: 2, float: 3.5, string: "b"}, {int: 3, float: 4.75, string: "c"}, {int: 4, float: 5.25, string: "d"}];
 
 module.exports = perspective => {
     describe("Execute", function() {
@@ -176,21 +177,21 @@ module.exports = perspective => {
     });
 
     describe("Typed Arrays", function() {
-        it("Ints to TypedArray in 0-sided view", async function() {
+        it("Int, 0-sided view", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view();
             const result = await view.col_to_js_typed_array("int");
             expect(result.byteLength).toEqual(16);
         });
 
-        it("Floats to TypedArray in 0-sided view", async function() {
+        it("Float, 0-sided view", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view();
             const result = await view.col_to_js_typed_array("float");
             expect(result.byteLength).toEqual(32);
         });
 
-        it("Ints to TypedArray in 1-sided view", async function() {
+        it("Int, 1-sided view", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view({
                 row_pivot: ["int"],
@@ -201,7 +202,7 @@ module.exports = perspective => {
             expect(result.byteLength).toEqual(20);
         });
 
-        it("Floats to TypedArray in 1-sided view", async function() {
+        it("Float, 1-sided view", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view({
                 row_pivot: ["int"],
@@ -209,6 +210,28 @@ module.exports = perspective => {
             });
             const result = await view.col_to_js_typed_array("float");
             expect(result.byteLength).toEqual(40);
+        });
+
+        it("Int, 2-sided view, no row pivot", async function() {
+            var table = perspective.table(int_float_data);
+            var view = table.view({column_pivot: ["float"]});
+            const result = await view.col_to_js_typed_array("3.5|int");
+            // bytelength should not include the aggregate row
+            expect(result.byteLength).toEqual(16);
+        });
+
+        it("Float, 2-sided view, no row pivot", async function() {
+            var table = perspective.table(int_float_data);
+            var view = table.view({column_pivot: ["float"]});
+            const result = await view.col_to_js_typed_array("3.5|float");
+            expect(result.byteLength).toEqual(32);
+        });
+
+        it("Undefined for non-int/float columns", async function() {
+            var table = perspective.table(int_float_string_data);
+            var view = table.view();
+            const result = await view.col_to_js_typed_array("string");
+            expect(result).toBeUndefined();
         });
     });
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -245,6 +245,60 @@ fill_col_dict(val dictvec, t_col_sptr col) {
 }
 } // namespace arrow
 
+namespace arraybuffer {
+val ArrayBuffer = val::global("ArrayBuffer");
+val Int8Array = val::global("Int8Array");
+val Int16Array = val::global("Int16Array");
+val Int32Array = val::global("Int32Array");
+val Float32Array = val::global("Float32Array");
+val Float64Array = val::global("Float64Array");
+
+val
+vec_to_arraybuffer(std::vector<const char*>& vec, t_dtype dtype) {
+    int vec_size = sizeof(vec[0]) * vec.size();
+    val buffer = ArrayBuffer.new_(vec_size);
+    val typed_array = arraybuffer::Int8Array.new_(buffer);
+
+    switch (dtype) {
+        case DTYPE_INT8: {
+            typed_array = arraybuffer::Int8Array.new_(buffer);
+        } break;
+        case DTYPE_INT16: {
+            typed_array = arraybuffer::Int16Array.new_(buffer);
+        } break;
+        case DTYPE_INT32:
+        case DTYPE_INT64: {
+            typed_array = arraybuffer::Int32Array.new_(buffer);
+        } break;
+        case DTYPE_FLOAT32: {
+            typed_array = arraybuffer::Float32Array.new_(buffer);
+        } break;
+        case DTYPE_FLOAT64: {
+            typed_array = arraybuffer::Float64Array.new_(buffer);
+        } break;
+        default:
+            return buffer;
+    }
+
+    return typed_array;
+}
+
+val
+col_to_arraybuffer(t_table_sptr tbl, val col_name) {
+    auto col = tbl->get_column(col_name.as<std::string>);
+    auto dtype = col->get_dtype();
+
+    std::vector<t_uchar> data;
+    data.reserve(col->size());
+    data.resize(col->size());
+
+    auto col_vect = col->fill(data, 0, col->size());
+    val buffer = arraybuffer::vec_to_arraybuffer(data, dtype);
+
+    return buffer;
+}
+} // namespace arraybuffer
+
 template <typename T>
 void
 _fill_col(val dcol, t_col_sptr col, t_bool is_arrow) {


### PR DESCRIPTION
Create C++/JS API to return view columns as a `TypedArray` for faster consumption and transferable usage.
