### PR TITLE
Remove subpath imports from external packages

### DIFF
--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -7,7 +7,6 @@
         "test": "test"
     },
     "files": [
-        "src/*",
         "build/*"
     ],
     "scripts": {

--- a/packages/perspective-viewer-highcharts/src/js/series.js
+++ b/packages/perspective-viewer-highcharts/src/js/series.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
+import {COLUMN_SEPARATOR_STRING} from "../../../../src/js/constants";
 
 function row_to_series(series, sname, gname) {
     let s;

--- a/packages/perspective-viewer-hypergrid/package.json
+++ b/packages/perspective-viewer-hypergrid/package.json
@@ -7,7 +7,6 @@
         "test": "test"
     },
     "files": [
-        "src/*",
         "build/*"
     ],
     "scripts": {

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
+import {COLUMN_SEPARATOR_STRING} from "../../../../src/js/constants";
 
 const TREE_COLUMN_INDEX = require("fin-hypergrid/src/behaviors/Behavior").prototype.treeColumnIndex;
 

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -4,7 +4,6 @@
     "description": "Perspective.js",
     "main": "build/perspective.view.cjs.js",
     "files": [
-        "src/*",
         "build/*"
     ],
     "scripts": {

--- a/packages/perspective-viewer/src/js/view.js
+++ b/packages/perspective-viewer/src/js/view.js
@@ -10,7 +10,7 @@ import "@webcomponents/webcomponentsjs";
 import _ from "underscore";
 import {polyfill} from "mobile-drag-drop";
 
-import perspective from "@jpmorganchase/perspective/src/js/perspective.parallel.js";
+import perspective from "@jpmorganchase/perspective";
 import {bindTemplate, json_attribute, array_attribute, copy_to_clipboard} from "./utils.js";
 
 import template from "../html/view.html";

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -7,7 +7,6 @@
         "access": "public"
     },
     "files": [
-        "src/*",
         "build/*",
         "index.d.ts"
     ],

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {AGGREGATE_DEFAULTS, FILTER_DEFAULTS, SORT_ORDERS, TYPE_AGGREGATES, TYPE_FILTERS, COLUMN_SEPARATOR_STRING} from "./defaults.js";
+import {AGGREGATE_DEFAULTS, FILTER_DEFAULTS, SORT_ORDERS, TYPE_AGGREGATES, TYPE_FILTERS, COLUMN_SEPARATOR_STRING} from "../../../../src/js/constants";
 import {DateParser, is_valid_date} from "./date_parser.js";
 import {bindall} from "./utils.js";
 

--- a/packages/perspective/src/js/perspective.parallel.js
+++ b/packages/perspective/src/js/perspective.parallel.js
@@ -9,7 +9,7 @@
 
 import {ScriptPath} from "./utils.js";
 
-import {TYPE_AGGREGATES, AGGREGATE_DEFAULTS, TYPE_FILTERS, FILTER_DEFAULTS, SORT_ORDERS} from "./defaults.js";
+import {TYPE_AGGREGATES, AGGREGATE_DEFAULTS, TYPE_FILTERS, FILTER_DEFAULTS, SORT_ORDERS} from "../../../../src/js/constants";
 
 import {worker} from "./api.js";
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -8,25 +8,25 @@
  */
 
 const NUMBER_AGGREGATES = [
-    "any",
-    "avg",
-    "count",
-    "distinct count",
-    "dominant",
-    "first by index",
-    "last by index",
-    "last",
-    "high",
-    "low",
-    "mean",
-    "mean by count",
-    "median",
-    "pct sum parent",
-    "pct sum grand total",
-    "sum",
-    "sum abs",
-    "sum not null",
-    "unique"
+  "any",
+  "avg",
+  "count",
+  "distinct count",
+  "dominant",
+  "first by index",
+  "last by index",
+  "last",
+  "high",
+  "low",
+  "mean",
+  "mean by count",
+  "median",
+  "pct sum parent",
+  "pct sum grand total",
+  "sum",
+  "sum abs",
+  "sum not null",
+  "unique"
 ];
 
 const STRING_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "dominant", "first by index", "last by index", "last", "mean by count", "unique"];
@@ -36,21 +36,21 @@ const BOOLEAN_AGGREGATES = ["any", "count", "distinct count", "distinct leaf", "
 export const SORT_ORDERS = ["asc", "desc", "none", "asc abs", "desc abs"];
 
 export const TYPE_AGGREGATES = {
-    string: STRING_AGGREGATES,
-    float: NUMBER_AGGREGATES,
-    integer: NUMBER_AGGREGATES,
-    boolean: BOOLEAN_AGGREGATES,
-    datetime: STRING_AGGREGATES,
-    date: STRING_AGGREGATES
+  string: STRING_AGGREGATES,
+  float: NUMBER_AGGREGATES,
+  integer: NUMBER_AGGREGATES,
+  boolean: BOOLEAN_AGGREGATES,
+  datetime: STRING_AGGREGATES,
+  date: STRING_AGGREGATES
 };
 
 export const AGGREGATE_DEFAULTS = {
-    string: "distinct count",
-    float: "sum",
-    integer: "sum",
-    boolean: "distinct count",
-    datetime: "distinct count",
-    date: "distinct count"
+  string: "distinct count",
+  float: "sum",
+  integer: "sum",
+  boolean: "distinct count",
+  datetime: "distinct count",
+  date: "distinct count"
 };
 
 const BOOLEAN_FILTERS = ["&", "|", "==", "!=", "or", "and"];
@@ -64,21 +64,21 @@ const DATETIME_FILTERS = ["<", ">", "==", "<=", ">=", "!="];
 export const COLUMN_SEPARATOR_STRING = "|";
 
 export const TYPE_FILTERS = {
-    string: STRING_FILTERS,
-    float: NUMBER_FILTERS,
-    integer: NUMBER_FILTERS,
-    boolean: BOOLEAN_FILTERS,
-    datetime: DATETIME_FILTERS,
-    date: DATETIME_FILTERS
+  string: STRING_FILTERS,
+  float: NUMBER_FILTERS,
+  integer: NUMBER_FILTERS,
+  boolean: BOOLEAN_FILTERS,
+  datetime: DATETIME_FILTERS,
+  date: DATETIME_FILTERS
 };
 
 export const FILTER_DEFAULTS = {
-    string: "==",
-    float: "==",
-    integer: "==",
-    boolean: "==",
-    datetime: "==",
-    date: "=="
+  string: "==",
+  float: "==",
+  integer: "==",
+  boolean: "==",
+  datetime: "==",
+  date: "=="
 };
 
 export const TYPED_ARRAY_SENTINEL_VALUE_INT8 = 255;


### PR DESCRIPTION
Since perspective.parallel.js is the entrypoint for `@jpmorganchase/perspective` this import is a no-op but means that all the files are processed again.