### PR TITLE
Moved babel-polyfill to avoid webpack/babel bug

### DIFF
--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -20,7 +20,7 @@
         "plugins": [
             "transform-decorators-legacy",
             "transform-custom-element-classes",
-            "transform-runtime",
+            ["transform-runtime", {"polyfill": false}],
             "transform-object-rest-spread",
             [
                 "transform-es2015-for-of",

--- a/packages/perspective-viewer-hypergrid/package.json
+++ b/packages/perspective-viewer-hypergrid/package.json
@@ -20,7 +20,7 @@
         "plugins": [
             "transform-decorators-legacy",
             "transform-custom-element-classes",
-            "transform-runtime",
+            ["transform-runtime", {"polyfill": false}],
             "transform-object-rest-spread",
             [
                 "transform-es2015-for-of",

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -20,7 +20,7 @@
         "plugins": [
             "transform-decorators-legacy",
             "transform-custom-element-classes",
-            "transform-runtime",
+            ["transform-runtime", {"polyfill": false}],
             "transform-object-rest-spread",
             [
                 "transform-es2015-for-of",

--- a/packages/perspective-viewer/src/config/view.config.js
+++ b/packages/perspective-viewer/src/config/view.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 const common = require("@jpmorganchase/perspective/src/config/common.config.js");
 
 module.exports = Object.assign({}, common(), {
-    entry: ["./src/js/view.js", "./src/less/default.less"],
+    entry: ["babel-polyfill", "./src/js/view.js", "./src/less/default.less"],
     output: {
         filename: "perspective.view.js",
         library: "perspective-view",

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -19,7 +19,7 @@
         "plugins": [
             "transform-decorators-legacy",
             "transform-custom-element-classes",
-            "transform-runtime",
+            ["transform-runtime", {"polyfill": false}],
             "transform-object-rest-spread",
             [
                 "transform-es2015-for-of",

--- a/packages/perspective/src/js/perspective.asmjs.js
+++ b/packages/perspective/src/js/perspective.asmjs.js
@@ -7,8 +7,6 @@
  *
  */
 
-import "babel-polyfill";
-
 const load_perspective = require("../../obj/psp.asmjs.js").load_perspective;
 const perspective = require("./perspective.js");
 


### PR DESCRIPTION
Moved bable-polyfill out of transform-runtime plugin to avoid a [webpack integration bug.](https://github.com/webpack/webpack/issues/3974#issuecomment-369260590)