### PR TITLE
Parallel tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
   - yarn lint
   - PSP_DOCKER=1 yarn build
   - PSP_DOCKER=1 yarn test:build
-  - yarn test:run_quiet
+  - yarn test:quietrun

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,7 +35,7 @@ If everything is successful, you should be able to run any of the `examples/`
 packages, e.g. `examples/simple` like so:
 
 ```bash
-npm start -- simple
+yarn start simple
 ```
 
 ### Building via EMSDK
@@ -107,7 +107,7 @@ You can run the test suite simply with the standard NPM command, which will both
 build the test suite for every package and run them.
 
 ```bash
-npm test
+yarn test
 ```
 
 The test suite is composed of two sections:  a Node.js test which asserts
@@ -131,7 +131,7 @@ screenshots reflect your change, you can update the new hashes manually in the
 environment variable:
 
 ```bash
-WRITE_TESTS=1 npm test
+WRITE_TESTS=1 yarn test
 ```
 
 ## Benchmarking

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
         "pretest:build": "lerna exec -- mkdir -p build",
         "test:build": "bash -c '[[ -z \"${PSP_DOCKER}\" ]] && npm run --silent _build_test || npm run --silent _emsdk -- npm run --silent _build_test'",
         "test:run": "npm run --silent clean:screenshots && npm run --silent _puppeteer -- node_modules/.bin/lerna exec --concurrency 1 --no-bail ${PACKAGE:+--scope=@jpmorganchase/${PACKAGE}} -- yarn --silent test:run",
-        "test:run_quiet": "npm run --silent _puppeteer -- node_modules/.bin/lerna run test:run",
+        "test:quietrun:jest": "output=$(jest --color --silent 2>&1); ret=$?; echo \"${output}\"; exit $ret",
+        "test:quietrun": "yarn --silent _puppeteer yarn --silent test:quietrun:jest",
+        "test:quickrun":  "yarn --silent clean:screenshots && yarn --silent _puppeteer yarn --silent jest --color --silent 2>&1",
+        "quicktest": "npm-run-all --silent lint test:build test:quickrun",
         "test": "npm-run-all --silent lint test:build test:run",
         "clean": "find obj -mindepth 1 -delete && lerna run clean ${PACKAGE:+--scope=@jpmorganchase/${PACKAGE}} --stream",
         "preclean:screenshots": "lerna exec -- mkdir -p screenshots",
@@ -66,5 +69,17 @@
         "_build_test": "lerna run test:build ${PACKAGE:+--scope=@jpmorganchase/${PACKAGE}} --stream",
         "_emsdk": "docker run --rm -it ${PSP_CPU_COUNT:+--cpus=\"${PSP_CPU_COUNT}.0\"} -v $(pwd):/src -e PACKAGE=${PACKAGE} perspective/emsdk",
         "_puppeteer": "docker run -it --rm --shm-size=2g ${PSP_CPU_COUNT:+--cpus=\"${PSP_CPU_COUNT}.0\"} -u root -e WRITE_TESTS=${WRITE_TESTS} -e PACKAGE=${PACKAGE} -v $(pwd):/src -w /src perspective/puppeteer"
+    },
+    "jest": {
+        "roots": [
+            "packages/perspective/build",
+            "packages/perspective-viewer/test/js",
+            "packages/perspective-viewer-hypergrid/test/js",
+            "packages/perspective-viewer-highcharts/test/js"
+        ],
+        "verbose": true,
+        "testURL": "http://localhost/",
+        "transform": {},
+        "automock": false
     }
 }

--- a/packages/perspective-viewer-highcharts/test/js/axis_tests.js
+++ b/packages/perspective-viewer-highcharts/test/js/axis_tests.js
@@ -8,27 +8,23 @@
  */
 
 exports.default = function() {
-    describe(
-        "axis tests",
-        () => {
-            test.capture("sets a category X axis when pivoted by a datetime.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => element.setAttribute("row-pivots", '["Order Date"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("aggregates", '{"State":"dominant","Sales":"sum"}'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-            });
+    describe("axis tests", () => {
+        test.capture("sets a category X axis when pivoted by a datetime.", async page => {
+            const viewer = await page.$("perspective-viewer");
+            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+            await page.evaluate(element => element.setAttribute("row-pivots", '["Order Date"]'), viewer);
+            await page.waitForSelector("perspective-viewer:not([updating])");
+            await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
+            await page.waitForSelector("perspective-viewer:not([updating])");
+            await page.evaluate(element => element.setAttribute("aggregates", '{"State":"dominant","Sales":"sum"}'), viewer);
+            await page.waitForSelector("perspective-viewer:not([updating])");
+        });
 
-            test.capture("sets a category axis when the axis type is a string.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-            });
-        },
-        {reload_page: false}
-    );
+        test.capture("sets a category axis when the axis type is a string.", async page => {
+            const viewer = await page.$("perspective-viewer");
+            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+            await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
+            await page.waitForSelector("perspective-viewer:not([updating])");
+        });
+    });
 };

--- a/packages/perspective-viewer-highcharts/test/js/axis_tests.js
+++ b/packages/perspective-viewer-highcharts/test/js/axis_tests.js
@@ -8,23 +8,27 @@
  */
 
 exports.default = function() {
-    describe("axis tests", () => {
-        test.capture("sets a category X axis when pivoted by a datetime.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("row-pivots", '["Order Date"]'), viewer);
-            await page.waitForSelector("perspective-viewer:not([updating])");
-            await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
-            await page.waitForSelector("perspective-viewer:not([updating])");
-            await page.evaluate(element => element.setAttribute("aggregates", '{"State":"dominant","Sales":"sum"}'), viewer);
-            await page.waitForSelector("perspective-viewer:not([updating])");
-        });
+    describe(
+        "axis tests",
+        () => {
+            test.capture("sets a category X axis when pivoted by a datetime.", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                await page.evaluate(element => element.setAttribute("row-pivots", '["Order Date"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.evaluate(element => element.setAttribute("aggregates", '{"State":"dominant","Sales":"sum"}'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            });
 
-        test.capture("sets a category axis when the axis type is a string.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
-            await page.waitForSelector("perspective-viewer:not([updating])");
-        });
-    });
+            test.capture("sets a category axis when the axis type is a string.", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["State","Sales"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            });
+        },
+        {reload_page: false}
+    );
 };

--- a/packages/perspective-viewer-highcharts/test/js/bar.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/bar.spec.js
@@ -8,6 +8,7 @@
  */
 
 const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
 
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
@@ -58,118 +59,122 @@ utils.with_server({}, () => {
                 });
             });
         },
-        {reload_page: false}
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 
-    describe.page("render_warning.html", () => {
-        test.capture("render warning should not show under size limit.", async page => {
-            await page.waitForSelector("perspective-viewer:not([updating])");
-        });
-
-        test.capture(
-            "render warning should show above size limit.",
-            async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => {
-                    window.getPlugin("y_bar").max_size = 50;
-                    element.setAttribute("columns", '["col_b"]');
-                }, viewer);
-                await page.waitForFunction(
-                    element => {
-                        return !element.shadowRoot.querySelector(".plugin_information.hidden");
-                    },
-                    {},
-                    viewer
-                );
-            },
-            {
-                timeout: 60000,
-                wait_for_update: false
-            }
-        );
-
-        test.capture(
-            "dismissing render warning should trigger render.",
-            async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => {
-                    window.getPlugin("y_bar").max_size = 50;
-                    element.setAttribute("columns", '["col_b"]');
-                }, viewer);
-                await page.waitForFunction(
-                    element => {
-                        return !element.shadowRoot.querySelector(".plugin_information.hidden");
-                    },
-                    {},
-                    viewer
-                );
-                await page.evaluate(element => element.shadowRoot.querySelector(".plugin_information__action").click(), viewer);
+    describe.page(
+        "render_warning.html",
+        () => {
+            test.capture("render warning should not show under size limit.", async page => {
                 await page.waitForSelector("perspective-viewer:not([updating])");
-            },
-            {
-                timeout: 100000,
-                wait_for_update: false
-            }
-        );
+            });
 
-        test.capture(
-            "selecting 'do not show again' should stop render warnings.",
-            async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => {
-                    window.getPlugin("y_bar").max_size = 50;
-                    element.setAttribute("columns", '["col_a", "col_b"]');
-                }, viewer);
-                await page.waitForFunction(
-                    element => {
-                        return !element.shadowRoot.querySelector(".plugin_information.hidden");
-                    },
-                    {},
-                    viewer
-                );
-                await page.evaluate(element => element.shadowRoot.querySelector(".plugin_information__action.plugin_information__action--dismiss").click(), viewer);
-                await page.evaluate(element => {
-                    element.setAttribute("columns", '["col_b"]');
-                }, viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])", {timeout: 100000});
-            },
-            {
-                timeout: 60000,
-                wait_for_update: false
-            }
-        );
+            test.capture(
+                "render warning should show above size limit.",
+                async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => {
+                        window.getPlugin("y_bar").max_size = 50;
+                        element.setAttribute("columns", '["col_b"]');
+                    }, viewer);
+                    await page.waitForFunction(
+                        element => {
+                            return !element.shadowRoot.querySelector(".plugin_information.hidden");
+                        },
+                        {},
+                        viewer
+                    );
+                },
+                {
+                    timeout: 60000,
+                    wait_for_update: false
+                }
+            );
 
-        test.capture(
-            "underlying data updates should not trigger rerender if warning is visible.",
-            async page => {
-                await page.evaluate(() => {
-                    window.getPlugin("y_bar").max_size = 50;
-                });
+            test.capture(
+                "dismissing render warning should trigger render.",
+                async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => {
+                        window.getPlugin("y_bar").max_size = 50;
+                        element.setAttribute("columns", '["col_b"]');
+                    }, viewer);
+                    await page.waitForFunction(
+                        element => {
+                            return !element.shadowRoot.querySelector(".plugin_information.hidden");
+                        },
+                        {},
+                        viewer
+                    );
+                    await page.evaluate(element => element.shadowRoot.querySelector(".plugin_information__action").click(), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                },
+                {
+                    timeout: 100000,
+                    wait_for_update: false
+                }
+            );
 
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => {
-                    element.setAttribute("columns", '["col_a", "col_b"]');
-                }, viewer);
-                await page.waitForSelector("perspective-viewer[updating]", {timeout: 100000});
-                await page.evaluate(element => {
-                    element.update([{col_a: 1234, col_b: 4321}]);
-                }, viewer);
-                await page.waitForFunction(
-                    element => {
-                        return !element.shadowRoot.querySelector(".plugin_information.hidden");
-                    },
-                    {},
-                    viewer
-                );
-            },
-            {
-                timeout: 60000,
-                wait_for_update: false
-            }
-        );
-    });
+            test.capture(
+                "selecting 'do not show again' should stop render warnings.",
+                async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => {
+                        window.getPlugin("y_bar").max_size = 50;
+                        element.setAttribute("columns", '["col_a", "col_b"]');
+                    }, viewer);
+                    await page.waitForFunction(
+                        element => {
+                            return !element.shadowRoot.querySelector(".plugin_information.hidden");
+                        },
+                        {},
+                        viewer
+                    );
+                    await page.evaluate(element => element.shadowRoot.querySelector(".plugin_information__action.plugin_information__action--dismiss").click(), viewer);
+                    await page.evaluate(element => {
+                        element.setAttribute("columns", '["col_b"]');
+                    }, viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])", {timeout: 100000});
+                },
+                {
+                    timeout: 60000,
+                    wait_for_update: false
+                }
+            );
+
+            test.capture(
+                "underlying data updates should not trigger rerender if warning is visible.",
+                async page => {
+                    await page.evaluate(() => {
+                        window.getPlugin("y_bar").max_size = 50;
+                    });
+
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => {
+                        element.setAttribute("columns", '["col_a", "col_b"]');
+                    }, viewer);
+                    await page.waitForSelector("perspective-viewer[updating]", {timeout: 100000});
+                    await page.evaluate(element => {
+                        element.update([{col_a: 1234, col_b: 4321}]);
+                    }, viewer);
+                    await page.waitForFunction(
+                        element => {
+                            return !element.shadowRoot.querySelector(".plugin_information.hidden");
+                        },
+                        {},
+                        viewer
+                    );
+                },
+                {
+                    timeout: 60000,
+                    wait_for_update: false
+                }
+            );
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
 });

--- a/packages/perspective-viewer-highcharts/test/js/bar.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/bar.spec.js
@@ -12,50 +12,54 @@ const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
 utils.with_server({}, () => {
-    describe.page("bar.html", () => {
-        simple_tests.default();
+    describe.page(
+        "bar.html",
+        () => {
+            simple_tests.default();
 
-        describe("tooltip tests", () => {
-            const bar = "rect.highcharts-point";
+            describe("tooltip tests", () => {
+                const bar = "rect.highcharts-point";
 
-            test.capture("tooltip shows on hover.", async page => {
-                await utils.invoke_tooltip(bar, page);
+                test.capture("tooltip shows on hover.", async page => {
+                    await utils.invoke_tooltip(bar, page);
+                });
+
+                test.capture("tooltip shows column label.", async page => {
+                    await utils.invoke_tooltip(bar, page);
+                });
+
+                test.capture("tooltip shows proper column labels based on hover target.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    // set a new column
+                    await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await utils.invoke_tooltip(bar, page);
+                });
+
+                test.capture("tooltip shows proper column labels based on hover target, pt2.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    // set a new column
+                    await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await utils.invoke_tooltip("rect.highcharts-color-1", page);
+                });
+
+                test.capture("tooltip shows pivot labels.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    // set a row pivot and a column pivot
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await utils.invoke_tooltip(bar, page);
+                });
             });
-
-            test.capture("tooltip shows column label.", async page => {
-                await utils.invoke_tooltip(bar, page);
-            });
-
-            test.capture("tooltip shows proper column labels based on hover target.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                // set a new column
-                await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await utils.invoke_tooltip(bar, page);
-            });
-
-            test.capture("tooltip shows proper column labels based on hover target, pt2.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                // set a new column
-                await page.evaluate(element => element.setAttribute("columns", '["Sales", "Profit"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await utils.invoke_tooltip("rect.highcharts-color-1", page);
-            });
-
-            test.capture("tooltip shows pivot labels.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                // set a row pivot and a column pivot
-                await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await utils.invoke_tooltip(bar, page);
-            });
-        });
-    });
+        },
+        {reload_page: false}
+    );
 
     describe.page("render_warning.html", () => {
         test.capture("render warning should not show under size limit.", async page => {
@@ -79,9 +83,10 @@ utils.with_server({}, () => {
                     viewer
                 );
             },
-            60000,
-            null,
-            false
+            {
+                timeout: 60000,
+                wait_for_update: false
+            }
         );
 
         test.capture(
@@ -103,9 +108,10 @@ utils.with_server({}, () => {
                 await page.evaluate(element => element.shadowRoot.querySelector(".plugin_information__action").click(), viewer);
                 await page.waitForSelector("perspective-viewer:not([updating])");
             },
-            100000,
-            null,
-            false
+            {
+                timeout: 100000,
+                wait_for_update: false
+            }
         );
 
         test.capture(
@@ -130,9 +136,10 @@ utils.with_server({}, () => {
                 }, viewer);
                 await page.waitForSelector("perspective-viewer:not([updating])", {timeout: 100000});
             },
-            60000,
-            null,
-            false
+            {
+                timeout: 60000,
+                wait_for_update: false
+            }
         );
 
         test.capture(
@@ -159,9 +166,10 @@ utils.with_server({}, () => {
                     viewer
                 );
             },
-            60000,
-            null,
-            false
+            {
+                timeout: 60000,
+                wait_for_update: false
+            }
         );
     });
 });

--- a/packages/perspective-viewer-highcharts/test/js/heatmap.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/heatmap.spec.js
@@ -8,6 +8,7 @@
  */
 
 const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
 
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
@@ -25,6 +26,6 @@ utils.with_server({}, () => {
                 });
             });
         },
-        {reload_page: false}
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 });

--- a/packages/perspective-viewer-highcharts/test/js/heatmap.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/heatmap.spec.js
@@ -12,15 +12,19 @@ const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
 utils.with_server({}, () => {
-    describe.page("heatmap.html", () => {
-        simple_tests.default();
+    describe.page(
+        "heatmap.html",
+        () => {
+            simple_tests.default();
 
-        describe("tooltip tests", () => {
-            const point = ".highcharts-point";
+            describe("tooltip tests", () => {
+                const point = ".highcharts-point";
 
-            test.capture("tooltip shows on hover.", async page => {
-                await utils.invoke_tooltip(point, page);
+                test.capture("tooltip shows on hover.", async page => {
+                    await utils.invoke_tooltip(point, page);
+                });
             });
-        });
-    });
+        },
+        {reload_page: false}
+    );
 });

--- a/packages/perspective-viewer-highcharts/test/js/line.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/line.spec.js
@@ -8,6 +8,7 @@
  */
 
 const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
 
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
@@ -50,6 +51,6 @@ utils.with_server({}, () => {
                 });
             });
         },
-        {reload_page: false}
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 });

--- a/packages/perspective-viewer-highcharts/test/js/line.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/line.spec.js
@@ -14,38 +14,42 @@ const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_t
 const axis_tests = require("./axis_tests.js");
 
 utils.with_server({}, () => {
-    describe.page("line.html", () => {
-        simple_tests.default();
+    describe.page(
+        "line.html",
+        () => {
+            simple_tests.default();
 
-        axis_tests.default();
+            axis_tests.default();
 
-        describe("tooltip tests", () => {
-            const series = "path.highcharts-graph";
+            describe("tooltip tests", () => {
+                const series = "path.highcharts-graph";
 
-            test.capture("tooltip shows on hover.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await utils.invoke_tooltip(series, page);
+                test.capture("tooltip shows on hover.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await utils.invoke_tooltip(series, page);
+                });
+
+                test.capture("tooltip shows proper column labels.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await utils.invoke_tooltip(series, page);
+                });
+
+                test.capture("tooltip shows pivot labels.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+
+                    // set a row pivot and a column pivot
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+
+                    await utils.invoke_tooltip(series, page);
+                });
             });
-
-            test.capture("tooltip shows proper column labels.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await utils.invoke_tooltip(series, page);
-            });
-
-            test.capture("tooltip shows pivot labels.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-
-                // set a row pivot and a column pivot
-                await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-
-                await utils.invoke_tooltip(series, page);
-            });
-        });
-    });
+        },
+        {reload_page: false}
+    );
 });

--- a/packages/perspective-viewer-highcharts/test/js/scatter.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/scatter.spec.js
@@ -8,6 +8,7 @@
  */
 
 const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
 
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
@@ -50,6 +51,6 @@ utils.with_server({}, () => {
                 });
             });
         },
-        {reload_page: false}
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 });

--- a/packages/perspective-viewer-highcharts/test/js/scatter.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/scatter.spec.js
@@ -14,38 +14,42 @@ const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_t
 const axis_tests = require("./axis_tests.js");
 
 utils.with_server({}, () => {
-    describe.page("scatter.html", () => {
-        simple_tests.default();
+    describe.page(
+        "scatter.html",
+        () => {
+            simple_tests.default();
 
-        axis_tests.default();
+            axis_tests.default();
 
-        describe("tooltip tests", () => {
-            const point = "path.highcharts-point";
+            describe("tooltip tests", () => {
+                const point = "path.highcharts-point";
 
-            test.capture("tooltip shows on hover.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await utils.invoke_tooltip(point, page);
+                test.capture("tooltip shows on hover.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await utils.invoke_tooltip(point, page);
+                });
+
+                test.capture("tooltip shows proper column labels.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await utils.invoke_tooltip(point, page);
+                });
+
+                test.capture("tooltip shows pivot labels.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+
+                    // set a row pivot and a column pivot
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+
+                    await utils.invoke_tooltip(point, page);
+                });
             });
-
-            test.capture("tooltip shows proper column labels.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await utils.invoke_tooltip(point, page);
-            });
-
-            test.capture("tooltip shows pivot labels.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-
-                // set a row pivot and a column pivot
-                await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-
-                await utils.invoke_tooltip(point, page);
-            });
-        });
-    });
+        },
+        {reload_page: false}
+    );
 });

--- a/packages/perspective-viewer-highcharts/test/js/treemap.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/treemap.spec.js
@@ -8,6 +8,7 @@
  */
 
 const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
 
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
@@ -32,6 +33,6 @@ utils.with_server({}, () => {
                 });
             });
         },
-        {reload_page: false}
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 });

--- a/packages/perspective-viewer-highcharts/test/js/treemap.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/treemap.spec.js
@@ -12,22 +12,26 @@ const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
 utils.with_server({}, () => {
-    describe.page("treemap.html", () => {
-        simple_tests.default();
+    describe.page(
+        "treemap.html",
+        () => {
+            simple_tests.default();
 
-        describe("tooltip tests", () => {
-            test.capture("tooltip shows on hover.", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+            describe("tooltip tests", () => {
+                test.capture("tooltip shows on hover.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
 
-                // set a row pivot and a column pivot so the graph will render
-                await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
+                    // set a row pivot and a column pivot so the graph will render
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["State"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
 
-                await utils.invoke_tooltip(".highcharts-point", page);
+                    await utils.invoke_tooltip(".highcharts-point", page);
+                });
             });
-        });
-    });
+        },
+        {reload_page: false}
+    );
 });

--- a/packages/perspective-viewer-hypergrid/package.json
+++ b/packages/perspective-viewer-hypergrid/package.json
@@ -14,7 +14,7 @@
         "bench:run": "echo \"No Benchmarks\"",
         "build": "webpack --color --config src/config/hypergrid.plugin.config.js",
         "test:build": "cp test/html/* build",
-        "test:run": "jest --silent --color 2>&1",
+        "test:run": "jest --silent --color",
         "test": "npm-run-all test:build test:run",
         "clean": "find build -mindepth 1 -delete",
         "clean:screenshots": "find screenshots/ \\( -name *.diff.png -o -name *.failed.png \\) -mindepth 1 -delete"

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -164,6 +164,7 @@ bindTemplate(TEMPLATE, style)(
 
                 host.setAttribute("hidden", true);
                 this.grid = new Hypergrid(host, {DataModel: PerspectiveDataModel});
+                this.grid.canvas.stopResizeLoop();
                 host.removeAttribute("hidden");
 
                 // window.g = this.grid; window.p = g.properties; // for debugging convenience in console
@@ -379,7 +380,7 @@ global.registerPlugin("hypergrid", {
     deselectMode: "pivots",
     resize: async function() {
         if (this.hypergrid) {
-            this.hypergrid.updateSize();
+            this.hypergrid.canvas.checksize();
             this.hypergrid.canvas.paintNow();
             let nrows = await this._view.num_rows();
             this.hypergrid.behavior.dataModel.setDirty(nrows);

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -7,6 +7,8 @@
  *
  */
 
+const rectangular = require("rectangular");
+
 /**
  * @this {Behavior}
  * @param payload
@@ -107,5 +109,58 @@ exports.install = function(grid) {
     Object.getPrototypeOf(grid.behavior).setPSP = setPSP;
     Object.getPrototypeOf(grid.behavior).cellClicked = function(event) {
         return this.dataModel.toggleRow(event.dataCell.y, event.dataCell.x, event);
+    };
+
+    // function isCanvasBlank(canvas) {
+    //     var blank = document.createElement("canvas");
+    //     blank.width = canvas.width;
+    //     blank.height = canvas.height;
+
+    //     return canvas.toDataURL() == blank.toDataURL();
+    // }
+
+    grid.canvas.resize = async function() {
+        const width = (this.width = Math.floor(this.div.clientWidth));
+        const height = (this.height = Math.floor(this.div.clientHeight));
+
+        //fix ala sir spinka, see
+        //http://www.html5rocks.com/en/tutorials/canvas/hidpi/
+        //just add 'hdpi' as an attribute to the fin-canvas tag
+        let ratio = 1;
+        const isHIDPI = window.devicePixelRatio && this.component.properties.useHiDPI;
+        if (isHIDPI) {
+            const devicePixelRatio = window.devicePixelRatio || 1;
+            const backingStoreRatio =
+                this.gc.webkitBackingStorePixelRatio || this.gc.mozBackingStorePixelRatio || this.gc.msBackingStorePixelRatio || this.gc.oBackingStorePixelRatio || this.gc.backingStorePixelRatio || 1;
+
+            ratio = devicePixelRatio / backingStoreRatio;
+        }
+
+        this.bounds = new rectangular.Rectangle(0, 0, width, height);
+        this.component.setBounds(this.bounds);
+        this.resizeNotification();
+
+        let render = false;
+        if (height * ratio > this.canvas.height) {
+            render = await new Promise(resolve => this.component.grid.behavior.dataModel.fetchData(undefined, resolve));
+        }
+
+        if (!render) {
+            this.bounds = new rectangular.Rectangle(0, 0, width, height);
+            this.component.setBounds(this.bounds);
+
+            this.buffer.width = this.canvas.width = width * ratio;
+            this.buffer.height = this.canvas.height = height * ratio;
+
+            this.canvas.style.width = this.buffer.style.width = width + "px";
+            this.canvas.style.height = this.buffer.style.height = height + "px";
+
+            this.bc.scale(ratio, ratio);
+            if (isHIDPI && !this.component.properties.useBitBlit) {
+                this.gc.scale(ratio, ratio);
+            }
+
+            grid.canvas.paintNow();
+        }
     };
 };

--- a/packages/perspective-viewer-hypergrid/test/js/regressions.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/regressions.spec.js
@@ -8,6 +8,7 @@
  */
 
 const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
 
 async function capture_update(page, viewer, body) {
     await page.evaluate(element => {
@@ -25,15 +26,19 @@ async function capture_update(page, viewer, body) {
 }
 
 utils.with_server({}, () => {
-    describe.page("empty.html", () => {
-        test.capture("empty grids do not explode", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.waitFor("perspective-viewer:not([updating])");
-            await capture_update(page, viewer, () => page.evaluate(element => element.update([{x: 3}]), viewer));
-            await page.waitFor("perspective-viewer:not([updating])");
-        });
-    });
+    describe.page(
+        "empty.html",
+        () => {
+            test.capture("empty grids do not explode", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                await page.waitFor("perspective-viewer:not([updating])");
+                await capture_update(page, viewer, () => page.evaluate(element => element.update([{x: 3}]), viewer));
+                await page.waitFor("perspective-viewer:not([updating])");
+            });
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
 
     describe.page(
         "regressions.html",
@@ -68,6 +73,6 @@ utils.with_server({}, () => {
                 });
             });
         },
-        {reload_page: true}
+        {root: path.join(__dirname, "..", "..")}
     );
 });

--- a/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
@@ -8,6 +8,7 @@
  */
 
 const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
 
 const simple_tests = require("@jpmorganchase/perspective-viewer/test/js/simple_tests.js");
 
@@ -65,6 +66,6 @@ utils.with_server({}, () => {
                 });
             });
         },
-        {reload_page: false}
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 });

--- a/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/superstore.spec.js
@@ -15,50 +15,56 @@ async function set_lazy(page) {
     const viewer = await page.$("perspective-viewer");
     await page.evaluate(element => {
         element.hypergrid.properties.repaintIntervalRate = 1;
-        Object.defineProperty(element.hypergrid, "_lazy_load", {
-            set: () => {},
-            get: () => true
-        });
+        if (!element.hypergrid._lazy_load) {
+            Object.defineProperty(element.hypergrid, "_lazy_load", {
+                set: () => {},
+                get: () => true
+            });
+        }
     }, viewer);
 }
 
 utils.with_server({}, () => {
-    describe.page("superstore.html", () => {
-        simple_tests.default();
+    describe.page(
+        "superstore.html",
+        () => {
+            simple_tests.default();
 
-        describe("expand/collapse", () => {
-            test.capture("collapses to depth smaller than viewport", async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.setAttribute("row-pivots", '["Category","State"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
+            describe("expand/collapse", () => {
+                test.capture("collapses to depth smaller than viewport", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["Category","State"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
 
-                await page.evaluate(element => {
-                    element.view.set_depth(0);
-                    element.notifyResize();
-                }, viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-            });
-        });
-
-        describe("lazy render mode", () => {
-            test.capture("resets viewable area when the logical size expands.", async page => {
-                await set_lazy(page);
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("row-pivots", '["City"]'), viewer);
+                    await page.evaluate(element => {
+                        element.view.set_depth(0);
+                        element.notifyResize();
+                    }, viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                });
             });
 
-            test.capture("resets viewable area when the physical size expands.", async page => {
-                await set_lazy(page);
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(element => element.setAttribute("row-pivots", '["Category"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-                await page.evaluate(element => element.setAttribute("row-pivots", "[]"), viewer);
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+            describe("lazy render mode", () => {
+                test.capture("resets viewable area when the logical size expands.", async page => {
+                    await set_lazy(page);
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => element.setAttribute("column-pivots", '["Category"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["City"]'), viewer);
+                });
+
+                test.capture("resets viewable area when the physical size expands.", async page => {
+                    await set_lazy(page);
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["Category"]'), viewer);
+                    await page.waitForSelector("perspective-viewer:not([updating])");
+                    await page.evaluate(element => element.setAttribute("row-pivots", "[]"), viewer);
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                });
             });
-        });
-    });
+        },
+        {reload_page: false}
+    );
 });

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -17,7 +17,7 @@
         "build": "npm-run-all build:*",
         "watch": "webpack --color --watch --config src/config/view.config.js",
         "test:build": "cp test/html/* build && cp test/csv/* build && cp test/css/* build",
-        "test:run": "jest --silent --color 2>&1",
+        "test:run": "jest --silent --color",
         "test": "npm-run-all test:build test:run",
         "clean": "find build -mindepth 1 -delete",
         "clean:screenshots": "find screenshots/ \\( -name *.failed.png -o -name *.diff.png \\) -mindepth 1 -delete",

--- a/packages/perspective-viewer/test/js/computed_columns.spec.js
+++ b/packages/perspective-viewer/test/js/computed_columns.spec.js
@@ -17,6 +17,7 @@
  */
 
 const utils = require("./utils.js");
+const path = require("path");
 
 const add_computed_column = async page => {
     const viewer = await page.$("perspective-viewer");
@@ -46,172 +47,178 @@ const add_computed_column = async page => {
 };
 
 utils.with_server({}, () => {
-    describe.page("superstore.html", () => {
-        describe.page(
-            undefined,
-            () => {
-                test.capture("click on add computed column button opens the UI.", async page => {
-                    const viewer = await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-                    await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-                });
+    describe.page(
+        "superstore.html",
+        () => {
+            describe.page(
+                undefined,
+                () => {
+                    test.capture("click on add computed column button opens the UI.", async page => {
+                        const viewer = await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                        await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                        await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                    });
 
-                test.capture("click on close button closes the UI.", async page => {
-                    const viewer = await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-                    await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-                    await page.evaluate(
-                        element =>
-                            element.shadowRoot
-                                .querySelector("perspective-computed-column")
-                                .shadowRoot.querySelector("#psp-cc__close")
-                                .click(),
-                        viewer
-                    );
-                });
+                    test.capture("click on close button closes the UI.", async page => {
+                        const viewer = await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                        await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                        await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                        await page.evaluate(
+                            element =>
+                                element.shadowRoot
+                                    .querySelector("perspective-computed-column")
+                                    .shadowRoot.querySelector("#psp-cc__close")
+                                    .click(),
+                            viewer
+                        );
+                    });
 
-                // input column
-                test.capture("setting a valid column should set it as input.", async page => {
-                    const viewer = await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-                    await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-                    await page.evaluate(element => {
-                        let com = element.shadowRoot.querySelector("perspective-computed-column");
-                        const columns = [{name: "State", type: "string"}];
-                        com._apply_state(columns, com.computations["lowercase"], "new_cc");
-                    }, viewer);
-                });
+                    // input column
+                    test.capture("setting a valid column should set it as input.", async page => {
+                        const viewer = await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                        await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                        await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                        await page.evaluate(element => {
+                            let com = element.shadowRoot.querySelector("perspective-computed-column");
+                            const columns = [{name: "State", type: "string"}];
+                            com._apply_state(columns, com.computations["lowercase"], "new_cc");
+                        }, viewer);
+                    });
 
-                test.capture("setting multiple column parameters should set input.", async page => {
-                    const viewer = await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-                    await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-                    await page.evaluate(element => {
-                        let com = element.shadowRoot.querySelector("perspective-computed-column");
-                        const columns = [{name: "Quantity", type: "integer"}, {name: "Row ID", type: "integer"}];
-                        com._apply_state(columns, com.computations["add"], "new_cc");
-                    }, viewer);
-                });
+                    test.capture("setting multiple column parameters should set input.", async page => {
+                        const viewer = await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                        await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                        await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                        await page.evaluate(element => {
+                            let com = element.shadowRoot.querySelector("perspective-computed-column");
+                            const columns = [{name: "Quantity", type: "integer"}, {name: "Row ID", type: "integer"}];
+                            com._apply_state(columns, com.computations["add"], "new_cc");
+                        }, viewer);
+                    });
 
-                // computation
-                test.capture("computations should clear input column.", async page => {
-                    const viewer = await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-                    await page.$("perspective-viewer");
-                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-                    await page.evaluate(element => {
-                        let com = element.shadowRoot.querySelector("perspective-computed-column");
-                        const columns = [{name: "State", type: "string"}];
-                        com._apply_state(columns, com.computations["lowercase"], "new_cc");
-                    }, viewer);
-                    await page.evaluate(element => {
-                        const select = element.shadowRoot.querySelector("perspective-computed-column").shadowRoot.querySelector("#psp-cc-computation__select");
-                        select.value = "subtract";
-                        select.dispatchEvent(new Event("change"));
-                    }, viewer);
-                    // await page.select("#psp-cc-computation__select", "subtract");
-                });
-            },
-            {reload_page: false, name: "UI interaction"}
-        );
-
-        // save
-        test.capture("saving without parameters should fail as button is disabled.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-            await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-            await page.evaluate(
-                element =>
-                    element.shadowRoot
-                        .querySelector("perspective-computed-column")
-                        .shadowRoot.querySelector("#psp-cc-button-save")
-                        .click(),
-                viewer
+                    // computation
+                    test.capture("computations should clear input column.", async page => {
+                        const viewer = await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                        await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                        await page.$("perspective-viewer");
+                        await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                        await page.evaluate(element => {
+                            let com = element.shadowRoot.querySelector("perspective-computed-column");
+                            const columns = [{name: "State", type: "string"}];
+                            com._apply_state(columns, com.computations["lowercase"], "new_cc");
+                        }, viewer);
+                        await page.evaluate(element => {
+                            const select = element.shadowRoot.querySelector("perspective-computed-column").shadowRoot.querySelector("#psp-cc-computation__select");
+                            select.value = "subtract";
+                            select.dispatchEvent(new Event("change"));
+                        }, viewer);
+                        // await page.select("#psp-cc-computation__select", "subtract");
+                    });
+                },
+                {reload_page: false, name: "UI interaction"}
             );
-        });
 
-        test.capture("saving a computed column should add it to inactive columns.", async page => {
-            await add_computed_column(page);
-        });
+            // save
+            test.capture("saving without parameters should fail as button is disabled.", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                await page.evaluate(
+                    element =>
+                        element.shadowRoot
+                            .querySelector("perspective-computed-column")
+                            .shadowRoot.querySelector("#psp-cc-button-save")
+                            .click(),
+                    viewer
+                );
+            });
 
-        test.capture("saving a duplicate column should fail with error message.", async page => {
-            await add_computed_column(page);
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-            await page.evaluate(element => {
-                let com = element.shadowRoot.querySelector("perspective-computed-column");
-                const columns = [{name: "Order Date", type: "datetime"}];
-                com._apply_state(columns, com.computations["day_of_week"], "new_cc");
-            }, viewer);
-            await page.evaluate(
-                element =>
-                    element.shadowRoot
-                        .querySelector("perspective-computed-column")
-                        .shadowRoot.querySelector("#psp-cc-button-save")
-                        .click(),
-                viewer
-            );
-        });
+            test.capture("saving a computed column should add it to inactive columns.", async page => {
+                await add_computed_column(page);
+            });
 
-        // edit
-        test.skip("clicking on the edit button should bring up the UI", async page => {
-            await add_computed_column(page);
-            await page.click("#row_edit");
-        });
+            test.capture("saving a duplicate column should fail with error message.", async page => {
+                await add_computed_column(page);
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                await page.evaluate(element => {
+                    let com = element.shadowRoot.querySelector("perspective-computed-column");
+                    const columns = [{name: "Order Date", type: "datetime"}];
+                    com._apply_state(columns, com.computations["day_of_week"], "new_cc");
+                }, viewer);
+                await page.evaluate(
+                    element =>
+                        element.shadowRoot
+                            .querySelector("perspective-computed-column")
+                            .shadowRoot.querySelector("#psp-cc-button-save")
+                            .click(),
+                    viewer
+                );
+            });
 
-        // usage
-        test.capture("aggregates by computed column.", async page => {
-            await add_computed_column(page);
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.setAttribute("row-pivots", '["Quantity"]'), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity", "new_cc"]'), viewer);
-        });
+            // edit
+            test.skip("clicking on the edit button should bring up the UI", async page => {
+                await add_computed_column(page);
+                await page.click("#row_edit");
+            });
 
-        test.capture("pivots by computed column.", async page => {
-            await add_computed_column(page);
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.setAttribute("row-pivots", '["new_cc"]'), viewer);
-        });
+            // usage
+            test.capture("aggregates by computed column.", async page => {
+                await add_computed_column(page);
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["Quantity"]'), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity", "new_cc"]'), viewer);
+            });
 
-        test.capture("adds computed column via attribute", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("computed-columns", '[{"name":"test","func":"month_bucket","inputs":["Order Date"]}]'), viewer);
-            await page.waitForSelector("perspective-viewer:not([updating])");
-            await page.evaluate(element => element.setAttribute("columns", '["Quantity", "test"]'), viewer);
-            await page.waitForSelector("perspective-viewer:not([updating])");
-        });
+            test.capture("pivots by computed column.", async page => {
+                await add_computed_column(page);
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["new_cc"]'), viewer);
+            });
 
-        test.capture("sorts by computed column.", async page => {
-            await add_computed_column(page);
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.setAttribute("sort", '["new_cc"]'), viewer);
-        });
+            test.capture("adds computed column via attribute", async page => {
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                await page.evaluate(element => element.setAttribute("computed-columns", '[{"name":"test","func":"month_bucket","inputs":["Order Date"]}]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+                await page.evaluate(element => element.setAttribute("columns", '["Quantity", "test"]'), viewer);
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            });
 
-        test.capture("filters by computed column.", async page => {
-            await add_computed_column(page);
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.setAttribute("filters", '[["new_cc", "==", "2 Monday"]]'), viewer);
-        });
+            test.capture("sorts by computed column.", async page => {
+                await add_computed_column(page);
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.setAttribute("sort", '["new_cc"]'), viewer);
+            });
 
-        test.capture("computed column aggregates should persist.", async page => {
-            await add_computed_column(page);
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.setAttribute("row-pivots", '["Quantity"]'), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity", "new_cc"]'), viewer);
-            await page.evaluate(element => element.setAttribute("aggregates", '{"new_cc":"any"}'), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity"]'), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity", "new_cc"]'), viewer);
-        });
-    });
+            test.capture("filters by computed column.", async page => {
+                await add_computed_column(page);
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.setAttribute("filters", '[["new_cc", "==", "2 Monday"]]'), viewer);
+            });
+
+            test.capture("computed column aggregates should persist.", async page => {
+                await add_computed_column(page);
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(element => element.setAttribute("row-pivots", '["Quantity"]'), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity", "new_cc"]'), viewer);
+                await page.evaluate(element => element.setAttribute("aggregates", '{"new_cc":"any"}'), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity"]'), viewer);
+                await page.evaluate(element => element.setAttribute("columns", '["Row ID", "Quantity", "new_cc"]'), viewer);
+            });
+        },
+        {
+            root: path.join(__dirname, "..", "..")
+        }
+    );
 });

--- a/packages/perspective-viewer/test/js/computed_columns.spec.js
+++ b/packages/perspective-viewer/test/js/computed_columns.spec.js
@@ -47,82 +47,84 @@ const add_computed_column = async page => {
 
 utils.with_server({}, () => {
     describe.page("superstore.html", () => {
-        test.capture("click on add computed column button opens the UI.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-            await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-        });
+        describe.page(
+            undefined,
+            () => {
+                test.capture("click on add computed column button opens the UI.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                    await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                });
 
-        test.capture("click on close button closes the UI.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-            await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-            await page.evaluate(
-                element =>
-                    element.shadowRoot
-                        .querySelector("perspective-computed-column")
-                        .shadowRoot.querySelector("#psp-cc__close")
-                        .click(),
-                viewer
-            );
-        });
+                test.capture("click on close button closes the UI.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                    await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                    await page.evaluate(
+                        element =>
+                            element.shadowRoot
+                                .querySelector("perspective-computed-column")
+                                .shadowRoot.querySelector("#psp-cc__close")
+                                .click(),
+                        viewer
+                    );
+                });
 
-        // input column
-        test.capture("setting a valid column should set it as input.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-            await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-            await page.evaluate(element => {
-                let com = element.shadowRoot.querySelector("perspective-computed-column");
-                const columns = [{name: "State", type: "string"}];
-                com._apply_state(columns, com.computations["lowercase"], "new_cc");
-            }, viewer);
-        });
+                // input column
+                test.capture("setting a valid column should set it as input.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                    await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                    await page.evaluate(element => {
+                        let com = element.shadowRoot.querySelector("perspective-computed-column");
+                        const columns = [{name: "State", type: "string"}];
+                        com._apply_state(columns, com.computations["lowercase"], "new_cc");
+                    }, viewer);
+                });
 
-        test.capture("setting multiple column parameters should set input.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-            await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-            await page.evaluate(element => {
-                let com = element.shadowRoot.querySelector("perspective-computed-column");
-                const columns = [{name: "Quantity", type: "integer"}, {name: "Row ID", type: "integer"}];
-                com._apply_state(columns, com.computations["add"], "new_cc");
-            }, viewer);
-        });
+                test.capture("setting multiple column parameters should set input.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                    await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                    await page.evaluate(element => {
+                        let com = element.shadowRoot.querySelector("perspective-computed-column");
+                        const columns = [{name: "Quantity", type: "integer"}, {name: "Row ID", type: "integer"}];
+                        com._apply_state(columns, com.computations["add"], "new_cc");
+                    }, viewer);
+                });
 
-        // computation
-        test.capture("computations should clear input column.", async page => {
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-            await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-            await page.$("perspective-viewer");
-            await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
-            await page.evaluate(element => {
-                let com = element.shadowRoot.querySelector("perspective-computed-column");
-                const columns = [{name: "State", type: "string"}];
-                com._apply_state(columns, com.computations["lowercase"], "new_cc");
-            }, viewer);
-            await page.evaluate(element => {
-                const select = element.shadowRoot.querySelector("perspective-computed-column").shadowRoot.querySelector("#psp-cc-computation__select");
-                select.value = "subtract";
-                select.dispatchEvent(new Event("change"));
-            }, viewer);
-            // await page.select("#psp-cc-computation__select", "subtract");
-        });
+                // computation
+                test.capture("computations should clear input column.", async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
+                    await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#add-computed-column").click(), viewer);
+                    await page.evaluate(element => {
+                        let com = element.shadowRoot.querySelector("perspective-computed-column");
+                        const columns = [{name: "State", type: "string"}];
+                        com._apply_state(columns, com.computations["lowercase"], "new_cc");
+                    }, viewer);
+                    await page.evaluate(element => {
+                        const select = element.shadowRoot.querySelector("perspective-computed-column").shadowRoot.querySelector("#psp-cc-computation__select");
+                        select.value = "subtract";
+                        select.dispatchEvent(new Event("change"));
+                    }, viewer);
+                    // await page.select("#psp-cc-computation__select", "subtract");
+                });
+            },
+            {reload_page: false, name: "UI interaction"}
+        );
 
         // save
-        test.capture("saving a computed column should add it to inactive columns.", async page => {
-            await add_computed_column(page);
-        });
-
         test.capture("saving without parameters should fail as button is disabled.", async page => {
             const viewer = await page.$("perspective-viewer");
             await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
@@ -136,6 +138,10 @@ utils.with_server({}, () => {
                         .click(),
                 viewer
             );
+        });
+
+        test.capture("saving a computed column should add it to inactive columns.", async page => {
+            await add_computed_column(page);
         });
 
         test.capture("saving a duplicate column should fail with error message.", async page => {

--- a/packages/perspective-viewer/test/js/leaks.spec.js
+++ b/packages/perspective-viewer/test/js/leaks.spec.js
@@ -8,99 +8,104 @@
  */
 
 const utils = require("./utils.js");
+const path = require("path");
 
 utils.with_server({}, () => {
-    describe.page("superstore.html", () => {
-        // must specify timeout AND viewport
-        test.capture(
-            "doesn't leak tables.",
-            async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                for (var i = 0; i < 100; i++) {
-                    await page.evaluate(element => element.load(window.__CSV__), viewer);
+    describe.page(
+        "superstore.html",
+        () => {
+            // must specify timeout AND viewport
+            test.capture(
+                "doesn't leak tables.",
+                async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    for (var i = 0; i < 100; i++) {
+                        await page.evaluate(element => element.load(window.__CSV__), viewer);
+                        await page.waitForSelector("perspective-viewer:not([updating])");
+                    }
+                    await page.evaluate(
+                        element =>
+                            element.load(
+                                window.__CSV__
+                                    .split("\n")
+                                    .slice(0, 10)
+                                    .join("\n")
+                            ),
+                        viewer
+                    );
                     await page.waitForSelector("perspective-viewer:not([updating])");
-                }
-                await page.evaluate(
-                    element =>
-                        element.load(
-                            window.__CSV__
-                                .split("\n")
-                                .slice(0, 10)
-                                .join("\n")
-                        ),
-                    viewer
-                );
-                await page.waitForSelector("perspective-viewer:not([updating])");
-            },
-            {timeout: 60000}
-        );
+                },
+                {timeout: 60000}
+            );
 
-        test.capture(
-            "doesn't leak elements.",
-            async page => {
-                let viewer = await page.$("perspective-viewer");
-                //await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                for (var i = 0; i < 100; i++) {
-                    viewer = await page.$("perspective-viewer");
-                    await page.evaluate(element => {
-                        element.delete();
-                        document.innerHTML = "<perspective_viewer></perspective-viewer>";
-                        document.getElementsByTagName("perspective-viewer")[0].load(window.__CSV__);
-                    }, viewer);
+            test.capture(
+                "doesn't leak elements.",
+                async page => {
+                    let viewer = await page.$("perspective-viewer");
+                    //await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    for (var i = 0; i < 100; i++) {
+                        viewer = await page.$("perspective-viewer");
+                        await page.evaluate(element => {
+                            element.delete();
+                            document.innerHTML = "<perspective_viewer></perspective-viewer>";
+                            document.getElementsByTagName("perspective-viewer")[0].load(window.__CSV__);
+                        }, viewer);
+                        await page.waitForSelector("perspective-viewer:not([updating])");
+                    }
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    await page.evaluate(
+                        element =>
+                            element.load(
+                                window.__CSV__
+                                    .split("\n")
+                                    .slice(0, 10)
+                                    .join("\n")
+                            ),
+                        viewer
+                    );
                     await page.waitForSelector("perspective-viewer:not([updating])");
-                }
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                await page.evaluate(
-                    element =>
-                        element.load(
-                            window.__CSV__
-                                .split("\n")
-                                .slice(0, 10)
-                                .join("\n")
-                        ),
-                    viewer
-                );
-                await page.waitForSelector("perspective-viewer:not([updating])");
-            },
-            {timeout: 60000}
-        );
+                },
+                {timeout: 60000}
+            );
 
-        test.capture(
-            "doesn't leak views when setting row pivots.",
-            async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                for (var i = 0; i < 100; i++) {
-                    await page.evaluate(element => {
-                        let pivots = ["State", "City", "Segment", "Ship Mode", "Region", "Category"];
-                        let start = Math.floor(Math.random() * pivots.length);
-                        let length = Math.ceil(Math.random() * (pivots.length - start));
-                        element.setAttribute("row-pivots", JSON.stringify(pivots.slice(start, length)));
-                    }, viewer);
+            test.capture(
+                "doesn't leak views when setting row pivots.",
+                async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    for (var i = 0; i < 100; i++) {
+                        await page.evaluate(element => {
+                            let pivots = ["State", "City", "Segment", "Ship Mode", "Region", "Category"];
+                            let start = Math.floor(Math.random() * pivots.length);
+                            let length = Math.ceil(Math.random() * (pivots.length - start));
+                            element.setAttribute("row-pivots", JSON.stringify(pivots.slice(start, length)));
+                        }, viewer);
+                        await page.waitForSelector("perspective-viewer:not([updating])");
+                    }
+                    await page.evaluate(element => element.setAttribute("row-pivots", '["Category"]'), viewer);
                     await page.waitForSelector("perspective-viewer:not([updating])");
-                }
-                await page.evaluate(element => element.setAttribute("row-pivots", '["Category"]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-            },
-            {timeout: 60000}
-        );
+                },
+                {timeout: 60000}
+            );
 
-        test.capture(
-            "doesn't leak views when setting filters.",
-            async page => {
-                const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
-                for (var i = 0; i < 100; i++) {
-                    await page.evaluate(element => {
-                        element.setAttribute("filters", JSON.stringify([["Sales", ">", Math.random() * 100 + 100]]));
-                    }, viewer);
+            test.capture(
+                "doesn't leak views when setting filters.",
+                async page => {
+                    const viewer = await page.$("perspective-viewer");
+                    await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                    for (var i = 0; i < 100; i++) {
+                        await page.evaluate(element => {
+                            element.setAttribute("filters", JSON.stringify([["Sales", ">", Math.random() * 100 + 100]]));
+                        }, viewer);
+                        await page.waitForSelector("perspective-viewer:not([updating])");
+                    }
+                    await page.evaluate(element => element.setAttribute("filters", '[["Sales", "<", 10]]'), viewer);
                     await page.waitForSelector("perspective-viewer:not([updating])");
-                }
-                await page.evaluate(element => element.setAttribute("filters", '[["Sales", "<", 10]]'), viewer);
-                await page.waitForSelector("perspective-viewer:not([updating])");
-            },
-            {timeout: 60000}
-        );
-    });
+                },
+                {timeout: 60000}
+            );
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
 });

--- a/packages/perspective-viewer/test/js/leaks.spec.js
+++ b/packages/perspective-viewer/test/js/leaks.spec.js
@@ -33,7 +33,7 @@ utils.with_server({}, () => {
                 );
                 await page.waitForSelector("perspective-viewer:not([updating])");
             },
-            60000
+            {timeout: 60000}
         );
 
         test.capture(
@@ -63,7 +63,7 @@ utils.with_server({}, () => {
                 );
                 await page.waitForSelector("perspective-viewer:not([updating])");
             },
-            60000
+            {timeout: 60000}
         );
 
         test.capture(
@@ -83,7 +83,7 @@ utils.with_server({}, () => {
                 await page.evaluate(element => element.setAttribute("row-pivots", '["Category"]'), viewer);
                 await page.waitForSelector("perspective-viewer:not([updating])");
             },
-            60000
+            {timeout: 60000}
         );
 
         test.capture(
@@ -100,7 +100,7 @@ utils.with_server({}, () => {
                 await page.evaluate(element => element.setAttribute("filters", '[["Sales", "<", 10]]'), viewer);
                 await page.waitForSelector("perspective-viewer:not([updating])");
             },
-            60000
+            {timeout: 60000}
         );
     });
 });

--- a/packages/perspective-viewer/test/js/regressions.spec.js
+++ b/packages/perspective-viewer/test/js/regressions.spec.js
@@ -8,45 +8,50 @@
  */
 
 const utils = require("./utils.js");
+const path = require("path");
 
 utils.with_server({}, () => {
-    describe.page("blank.html", () => {
-        test.capture("Handles reloading with a schema.", async page => {
-            var schema = {_pkey: "string", a: "string"};
-            var data = {a: "a"};
+    describe.page(
+        "blank.html",
+        () => {
+            test.capture("Handles reloading with a schema.", async page => {
+                var schema = {_pkey: "string", a: "string"};
+                var data = {a: "a"};
 
-            function getData(ver, count) {
-                var rows = [];
-                for (var index = 0; index < count; index++) {
-                    var row = Object.assign({}, data);
-                    row._pkey = String(ver) + "_" + index;
-                    rows.push(row);
+                function getData(ver, count) {
+                    var rows = [];
+                    for (var index = 0; index < count; index++) {
+                        var row = Object.assign({}, data);
+                        row._pkey = String(ver) + "_" + index;
+                        rows.push(row);
+                    }
+                    return rows;
                 }
-                return rows;
-            }
 
-            const viewer = await page.$("perspective-viewer");
-            await page.evaluate(
-                (viewer, data, schema) => {
-                    viewer.load(schema);
-                    viewer.update(data);
-                },
-                viewer,
-                getData(2, 1),
-                schema
-            );
+                const viewer = await page.$("perspective-viewer");
+                await page.evaluate(
+                    (viewer, data, schema) => {
+                        viewer.load(schema);
+                        viewer.update(data);
+                    },
+                    viewer,
+                    getData(2, 1),
+                    schema
+                );
 
-            await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
+                await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
 
-            await page.evaluate(
-                (viewer, data, schema) => {
-                    viewer.load(schema);
-                    viewer.update(data);
-                },
-                viewer,
-                getData(3, 2),
-                schema
-            );
-        });
-    });
+                await page.evaluate(
+                    (viewer, data, schema) => {
+                        viewer.load(schema);
+                        viewer.update(data);
+                    },
+                    viewer,
+                    getData(3, 2),
+                    schema
+                );
+            });
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
 });

--- a/packages/perspective-viewer/test/js/responsive_tests.js
+++ b/packages/perspective-viewer/test/js/responsive_tests.js
@@ -21,7 +21,6 @@ exports.default = function() {
             await page.evaluate(element => element.shadowRoot.querySelector("#config_button").click(), viewer);
             await page.evaluate(element => element.setAttribute("columns", '["Discount","Profit","Sales"]'), viewer);
         },
-        60000,
-        viewport
+        {timeout: 60000, viewport}
     );
 };

--- a/packages/perspective-viewer/test/js/superstore.spec.js
+++ b/packages/perspective-viewer/test/js/superstore.spec.js
@@ -13,11 +13,15 @@ const simple_tests = require("./simple_tests.js");
 const responsive_tests = require("./responsive_tests");
 
 utils.with_server({}, () => {
-    describe.page("superstore.html", () => {
-        simple_tests.default();
+    describe.page(
+        "superstore.html",
+        () => {
+            simple_tests.default();
 
-        describe("Responsive Layout", () => {
-            responsive_tests.default();
-        });
-    });
+            describe("Responsive Layout", () => {
+                responsive_tests.default();
+            });
+        },
+        {reload_page: false}
+    );
 });

--- a/packages/perspective-viewer/test/js/superstore.spec.js
+++ b/packages/perspective-viewer/test/js/superstore.spec.js
@@ -11,6 +11,7 @@ const utils = require("./utils.js");
 
 const simple_tests = require("./simple_tests.js");
 const responsive_tests = require("./responsive_tests");
+const path = require("path");
 
 utils.with_server({}, () => {
     describe.page(
@@ -22,6 +23,6 @@ utils.with_server({}, () => {
                 responsive_tests.default();
             });
         },
-        {reload_page: false}
+        {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 });

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -37,7 +37,7 @@
         "test:build:webpack": "npm-run-all -p test:build:webpack:*",
         "test:build:webpack:browser": "webpack --color --config test/config/test_browser.config.js",
         "test:build:webpack:node": "webpack --color --config test/config/test_node.config.js",
-        "test:run": "jest --runInBand --color 2>&1",
+        "test:run": "jest --color --ci",
         "test": "npm-run-all test:build test:run",
         "clean": "find build -mindepth 1 -delete && find obj -mindepth 1 -delete"
     },

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1192,7 +1192,7 @@ export default function(Module) {
      * @param {Computation} computed A computation specification object
      */
     table.prototype.add_computed = function(computed) {
-        let pool, gnode, tbl;
+        let pool, gnode;
 
         try {
             pool = new __MODULE__.t_pool();
@@ -1200,7 +1200,6 @@ export default function(Module) {
             if (this.computed.length > 0) {
                 computed = this.computed.concat(computed);
             }
-
             return new table(gnode, pool, this.index, computed, this.limit, this.limit_index);
         } catch (e) {
             if (pool) {
@@ -1210,10 +1209,6 @@ export default function(Module) {
                 gnode.delete();
             }
             throw e;
-        } finally {
-            if (tbl) {
-                tbl.delete();
-            }
         }
     };
 


### PR DESCRIPTION
Further parallelize Puppeteer test suite by reusing the `page` object between tests, and allow `jest` to run all package tests in parallel.