### PR TITLE
Build into dist, plays nicer with ipywidgets

### DIFF
--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -3,17 +3,17 @@
     "version": "0.2.9",
     "description": "Perspective.js",
     "files": [
-        "build/*.d.ts",
-        "build/*.js.map",
-        "build/*.js",
-        "build/*.wasm",
+        "dist/*.d.ts",
+        "dist/*.js.map",
+        "dist/*.js",
+        "dist/*.wasm",
         "src/css/*.css",
         "babel.config.js"
     ],
-    "main": "build/index.js",
-    "types": "build/index.d.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "directories": {
-        "build": "build/"
+        "dist: "dist/"
     },
     "license": "Apache-2.0",
     "publishConfig": {
@@ -39,6 +39,6 @@
         "@phosphor/widgets": "^1.5.0"
     },
     "jupyterlab": {
-        "extension": "build/index.js"
+        "extension": "dist/index.js"
     }
 }

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -13,7 +13,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "directories": {
-        "dist: "dist/"
+        "dist": "dist/"
     },
     "license": "Apache-2.0",
     "publishConfig": {

--- a/packages/perspective-jupyterlab/src/config/mimerenderer.config.js
+++ b/packages/perspective-jupyterlab/src/config/mimerenderer.config.js
@@ -25,6 +25,6 @@ module.exports = Object.assign({}, common(), {
     output: {
         filename: "mime.js",
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../build")
+        path: path.resolve(__dirname, "../../dist")
     }
 });

--- a/packages/perspective-jupyterlab/src/config/plugin.config.js
+++ b/packages/perspective-jupyterlab/src/config/plugin.config.js
@@ -32,6 +32,6 @@ module.exports = {
     output: {
         filename: "index.js",
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "../../build")
+        path: path.resolve(__dirname, "../../dist")
     }
 };

--- a/packages/perspective-jupyterlab/tsconfig.json
+++ b/packages/perspective-jupyterlab/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "allowJs": true,
     "target": "ES5",
-    "outDir": "./build",
+    "outDir": "./dist",
     "lib": ["ES5", "ES2015.Promise", "DOM", "ES2015.Collection"],
     "types": []
   },


### PR DESCRIPTION
`ipywidgets` embedding expects the output to be dist:
https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/html-manager/src/libembed-amd.ts#L46
