### PR TITLE
Empty string column type inference fix

### DIFF
--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -462,6 +462,15 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("Infers correct type for empty string columns", async function() {
+            var table = perspective.table([{x: "", y: 1}, {x: "", y: 2}, {x: "", y: 3}, {x: "", y: 4}]);
+            var view = table.view();
+            let result = await view.schema();
+            expect(result).toEqual({x: "string", y: "integer"});
+            view.delete();
+            table.delete();
+        });
+
         it.skip("Upgrades integer columns with values beyond max/min_int to float", async function() {
             const schema = {
                 a: "integer"

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -909,7 +909,7 @@ column_names(val data, t_int32 format) {
 t_dtype
 infer_type(val x, val moment, val candidates) {
     t_str jstype = x.typeOf().as<t_str>();
-    t_dtype t = t_dtype::DTYPE_FLOAT64;
+    t_dtype t = t_dtype::DTYPE_STR;
 
     if (x.isNull()) {
         t = t_dtype::DTYPE_NONE;
@@ -933,18 +933,21 @@ infer_type(val x, val moment, val candidates) {
         } else {
             t = t_dtype::DTYPE_TIME;
         }
-    } else if (!val::global("isNaN").call<t_bool>("call", val::object(), val::global("Number").call<val>("call", val::object(), x))) {
-        t = t_dtype::DTYPE_FLOAT64;
-    } else if (jstype == "string" && is_valid_date(moment, candidates, x)) {
-        t = t_dtype::DTYPE_TIME;
     } else if (jstype == "string") {
-        t_str lower = x.call<val>("toLowerCase").as<t_str>();
-        if (lower == "true" || lower == "false") {
-            t = t_dtype::DTYPE_BOOL;
+        if (is_valid_date(moment, candidates, x)) {
+            t = t_dtype::DTYPE_TIME;
         } else {
-            t = t_dtype::DTYPE_STR;
+            t_str lower = x.call<val>("toLowerCase").as<t_str>();
+            if (lower == "true" || lower == "false") {
+                t = t_dtype::DTYPE_BOOL;
+            } else {
+                t = t_dtype::DTYPE_STR;
+            }
         }
-    }
+    } else if (!val::global("isNaN").call<t_bool>("call", val::object(), val::global("Number").call<val>("call", val::object(), x))) {
+        PSP_COMPLAIN_AND_ABORT("BADLANDS");
+        t = t_dtype::DTYPE_FLOAT64;
+    } 
 
     return t;
 }


### PR DESCRIPTION
Fixed issue which inferred a type `"float"` when given a schema-less JS column of all empty strings.