### PR TITLE
Fix #291 Null values in filters

### DIFF
--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -971,13 +971,19 @@ export default function(Module) {
 
         if (config.filter) {
             let schema = this._schema();
-            filters = config.filter.map(function(filter) {
-                if (schema[filter[0]] === "datetime" || schema[filter[0]] === "date") {
-                    return [filter[0], _string_to_filter_op[filter[1]], new DateParser().parse(filter[2])];
-                } else {
-                    return [filter[0], _string_to_filter_op[filter[1]], filter[2]];
-                }
-            });
+            let isDateFilter = key => schema[key] === "datetime" || schema[key] === "date";
+            filters = config.filter
+                .filter(filter => {
+                    const value = isDateFilter(filter[0]) ? new DateParser().parse(filter[2]) : filter[2];
+                    return typeof value !== "undefined" && value !== null;
+                })
+                .map(filter => {
+                    if (isDateFilter(filter[0])) {
+                        return [filter[0], _string_to_filter_op[filter[1]], new DateParser().parse(filter[2])];
+                    } else {
+                        return [filter[0], _string_to_filter_op[filter[1]], filter[2]];
+                    }
+                });
             if (config.filter_op) {
                 filter_op = _string_to_filter_op[config.filter_op];
             }

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -265,6 +265,20 @@ module.exports = perspective => {
                 view.delete();
                 table.delete();
             });
+
+            it("x == null", async function() {
+                var table = perspective.table({x: "float", y: "integer"});
+                const dataSet = [{x: 3.5, y: 1}, {x: 2.5, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4.5, y: 2}, {x: null, y: 2}];
+                table.update(dataSet);
+                var view = table.view({
+                    filter: [["x", ">", null]]
+                });
+                var answer = dataSet;
+                let result = await view.to_json();
+                expect(answer).toEqual(result);
+                view.delete();
+                table.delete();
+            });
         });
     });
 };


### PR DESCRIPTION
Fixes #291 

Added a check to ignore filters where the operand is null or undefined.
Added associated test to check for this functionality.