### PR TITLE
Test quality-of-life updates

### DIFF
--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -118,10 +118,14 @@ var arrow_result = [
     }
 ];
 
-var dt = new Date();
-dt.setHours(4);
-dt.setMinutes(12);
-var data_4 = [{v: dt}];
+var dt = () => {
+    let dt = new Date();
+    dt.setHours(4);
+    dt.setMinutes(12);
+    return dt;
+};
+
+var data_4 = [{v: dt()}];
 
 var data_5 = [{v: "11-09-2017"}];
 
@@ -356,8 +360,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({});
             var answer = `x,y,z\r\n1,a,true\r\n2,b,false\r\n3,c,true\r\n4,d,false`;
-            let result2 = await view.to_csv();
-            expect(answer).toEqual(result2);
+            let result = await view.to_csv();
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -369,8 +373,8 @@ module.exports = perspective => {
                 aggregate: [{op: "sum", column: "x"}]
             });
             var answer = `__ROW_PATH__,x\r\n,10\r\nfalse,6\r\ntrue,4`;
-            let result2 = await view.to_csv();
-            expect(answer).toEqual(result2);
+            let result = await view.to_csv();
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -383,8 +387,8 @@ module.exports = perspective => {
                 aggregate: [{op: "sum", column: "x"}]
             });
             var answer = `__ROW_PATH__,\"a,x\",\"b,x\",\"c,x\",\"d,x\"\r\n,1,2,3,4\r\nfalse,,2,,4\r\ntrue,1,,3,`;
-            let result2 = await view.to_csv();
-            expect(answer).toEqual(result2);
+            let result = await view.to_csv();
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -392,8 +396,8 @@ module.exports = perspective => {
         it("Serializes a simple view to column-oriented JSON", async function() {
             var table = perspective.table(data_3);
             var view = table.view({});
-            let result2 = await view.to_columns();
-            expect(data_7).toEqual(result2);
+            let result = await view.to_columns();
+            expect(result).toEqual(data_7);
             view.delete();
             table.delete();
         });
@@ -404,7 +408,7 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view();
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -413,7 +417,7 @@ module.exports = perspective => {
             var table = perspective.table(col_data);
             var view = table.view();
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -422,7 +426,7 @@ module.exports = perspective => {
             var table = perspective.table(arrow.slice());
             var view = table.view();
             let result = await view.to_json();
-            expect(arrow_result).toEqual(result);
+            expect(result).toEqual(arrow_result);
             view.delete();
             table.delete();
         });
@@ -440,7 +444,7 @@ module.exports = perspective => {
             var table = perspective.table(csv);
             var view = table.view();
             let result = await view.to_json();
-            expect(papaparse.parse(csv, {header: true, dynamicTyping: true}).data).toEqual(result);
+            expect(result).toEqual(papaparse.parse(csv, {header: true, dynamicTyping: true}).data);
             view.delete();
             table.delete();
         });
@@ -449,7 +453,7 @@ module.exports = perspective => {
             var table = perspective.table(meta);
             var view = table.view();
             let result = await view.to_json();
-            expect([]).toEqual(result);
+            expect(result).toEqual([]);
             view.delete();
             table.delete();
         });
@@ -458,7 +462,7 @@ module.exports = perspective => {
             var table = perspective.table(data_3);
             var view = table.view();
             let result = await view.to_json();
-            expect(data_3).toEqual(result);
+            expect(result).toEqual(data_3);
             view.delete();
             table.delete();
         });
@@ -533,14 +537,14 @@ module.exports = perspective => {
         it("Handles floats schemas", async function() {
             var table = perspective.table(data_3);
             let result = await table.schema();
-            expect(meta_3).toEqual(result);
+            expect(result).toEqual(meta_3);
             table.delete();
         });
 
         it("Generates correct date schemas", async function() {
             var table = perspective.table(data_4);
             let result = await table.schema();
-            expect(meta_4).toEqual(result);
+            expect(result).toEqual(meta_4);
             table.delete();
         });
 
@@ -549,7 +553,7 @@ module.exports = perspective => {
             table.update(data_4);
             let view = table.view();
             let result = await view.to_json();
-            expect([{v: +data_4[0]["v"]}]).toEqual(result);
+            expect(result).toEqual([{v: +data_4[0]["v"]}]);
             view.delete();
             table.delete();
         });
@@ -557,8 +561,8 @@ module.exports = perspective => {
         it("Handles datetime values", async function() {
             var table = perspective.table(data_4);
             let view = table.view();
-            let result2 = await view.to_json();
-            expect([{v: +data_4[0]["v"]}]).toEqual(result2);
+            let result = await view.to_json();
+            expect(result).toEqual([{v: +data_4[0]["v"]}]);
             view.delete();
             table.delete();
         });
@@ -566,8 +570,8 @@ module.exports = perspective => {
         it("Handles datetime strings", async function() {
             var table = perspective.table(data_5);
             let view = table.view();
-            let result2 = await view.to_json();
-            expect([{v: +moment(data_5[0]["v"], "MM-DD-YYYY")}]).toEqual(result2);
+            let result = await view.to_json();
+            expect(result).toEqual([{v: +moment(data_5[0]["v"], "MM-DD-YYYY")}]);
             view.delete();
             table.delete();
         });
@@ -576,13 +580,13 @@ module.exports = perspective => {
             var table = perspective.table({v: "date"});
             table.update(data_4);
             let view = table.view();
-            let result2 = await view.to_json();
+            let result = await view.to_json();
             let d = new Date(data_4[0]["v"]);
             d.setHours(0);
             d.setMinutes(0);
             d.setSeconds(0);
             d.setMilliseconds(0);
-            expect([{v: +d}]).toEqual(result2);
+            expect(result).toEqual([{v: +d}]);
             view.delete();
             table.delete();
         });
@@ -591,7 +595,7 @@ module.exports = perspective => {
             var table = perspective.table(data_6);
             let view = table.view({});
             let result = await view.to_json();
-            expect(data_6).toEqual(result);
+            expect(result).toEqual(data_6);
             view.delete();
             table.delete();
         });
@@ -609,8 +613,7 @@ module.exports = perspective => {
             ]);
             let view = table2.view({aggregate: [{op: "count", column: "const"}]});
             let result = await view.to_json();
-            let expected = [{const: 1}, {const: 1}, {const: 1}, {const: 1}];
-            expect(expected).toEqual(result);
+            expect(result).toEqual([{const: 1}, {const: 1}, {const: 1}, {const: 1}]);
             view.delete();
             table2.delete();
             table.delete();
@@ -629,8 +632,7 @@ module.exports = perspective => {
             ]);
             let view = table2.view({aggregate: [{op: "count", column: "ratio"}]});
             let result = await view.to_json();
-            let expected = [{ratio: 1.5}, {ratio: 1.25}, {ratio: 1.1666666666666667}, {ratio: 1.125}];
-            expect(expected).toEqual(result);
+            expect(result).toEqual([{ratio: 1.5}, {ratio: 1.25}, {ratio: 1.1666666666666667}, {ratio: 1.125}]);
             view.delete();
             table2.delete();
             table.delete();
@@ -660,7 +662,7 @@ module.exports = perspective => {
             let view = table2.view({aggregate: [{op: "count", column: "y"}, {op: "count", column: "ratio"}]});
             let result = await view.to_json();
             let expected = [{y: "a", ratio: 1.5}, {y: "b", ratio: 1.25}, {y: "c", ratio: 1.1666666666666667}, {y: "d", ratio: 1.125}];
-            expect(expected).toEqual(result);
+            expect(result).toEqual(expected);
             view.delete();
             table2.delete();
             table.delete();
@@ -719,7 +721,7 @@ module.exports = perspective => {
                 }
             };
 
-            expect(expected).toEqual(result);
+            expect(result).toEqual(expected);
             table2.delete();
             table.delete();
         });

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -9,6 +9,7 @@
 
 var yesterday = new Date();
 yesterday.setDate(yesterday.getDate() - 1);
+
 var now = new Date();
 
 var data = [{w: now, x: 1, y: "a", z: true}, {w: now, x: 2, y: "b", z: false}, {w: now, x: 3, y: "c", z: true}, {w: yesterday, x: 4, y: "d", z: false}];
@@ -35,7 +36,7 @@ module.exports = perspective => {
                     filter: [["x", ">", 2.0]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(2)).toEqual(json);
+                expect(json).toEqual(rdata.slice(2));
                 view.delete();
                 table.delete();
             });
@@ -46,7 +47,7 @@ module.exports = perspective => {
                     filter: [["x", "<", 3.0]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(0, 2)).toEqual(json);
+                expect(json).toEqual(rdata.slice(0, 2));
                 view.delete();
                 table.delete();
             });
@@ -57,7 +58,7 @@ module.exports = perspective => {
                     filter: [["x", ">", 4]]
                 });
                 let json = await view.to_json();
-                expect([]).toEqual(json);
+                expect(json).toEqual([]);
                 view.delete();
                 table.delete();
             });
@@ -68,7 +69,7 @@ module.exports = perspective => {
                     filter: [["x", ">", 4]]
                 });
                 let json = await view.to_json();
-                expect([]).toEqual(json);
+                expect(json).toEqual([]);
                 view.delete();
                 table.delete();
             });
@@ -81,7 +82,7 @@ module.exports = perspective => {
                     filter: [["x", "==", 1]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(0, 1)).toEqual(json);
+                expect(json).toEqual(rdata.slice(0, 1));
                 view.delete();
                 table.delete();
             });
@@ -92,7 +93,7 @@ module.exports = perspective => {
                     filter: [["x", "==", 5]]
                 });
                 let json = await view.to_json();
-                expect([]).toEqual(json);
+                expect(json).toEqual([]);
                 view.delete();
                 table.delete();
             });
@@ -103,7 +104,7 @@ module.exports = perspective => {
                     filter: [["y", "==", "a"]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(0, 1)).toEqual(json);
+                expect(json).toEqual(rdata.slice(0, 1));
                 view.delete();
                 table.delete();
             });
@@ -114,7 +115,7 @@ module.exports = perspective => {
                     filter: [["y", "==", "e"]]
                 });
                 let json = await view.to_json();
-                expect([]).toEqual(json);
+                expect(json).toEqual([]);
                 view.delete();
                 table.delete();
             });
@@ -125,7 +126,7 @@ module.exports = perspective => {
                     filter: [["z", "==", true]]
                 });
                 let json = await view.to_json();
-                expect([rdata[0], rdata[2]]).toEqual(json);
+                expect(json).toEqual([rdata[0], rdata[2]]);
                 view.delete();
                 table.delete();
             });
@@ -136,7 +137,7 @@ module.exports = perspective => {
                     filter: [["z", "==", false]]
                 });
                 let json = await view.to_json();
-                expect([rdata[1], rdata[3]]).toEqual(json);
+                expect(json).toEqual([rdata[1], rdata[3]]);
                 view.delete();
                 table.delete();
             });
@@ -147,7 +148,7 @@ module.exports = perspective => {
                     filter: [["w", "==", yesterday]]
                 });
                 let json = await view.to_json();
-                expect([rdata[3]]).toEqual(json);
+                expect(json).toEqual([rdata[3]]);
                 view.delete();
                 table.delete();
             });
@@ -158,7 +159,7 @@ module.exports = perspective => {
                     filter: [["w", "!=", yesterday]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(0, 3)).toEqual(json);
+                expect(json).toEqual(rdata.slice(0, 3));
                 view.delete();
                 table.delete();
             });
@@ -171,7 +172,7 @@ module.exports = perspective => {
                     filter: [["y", "in", ["a", "b"]]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(0, 2)).toEqual(json);
+                expect(json).toEqual(rdata.slice(0, 2));
                 view.delete();
                 table.delete();
             });
@@ -184,7 +185,7 @@ module.exports = perspective => {
                     filter: [["y", "not in", ["d"]]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(0, 3)).toEqual(json);
+                expect(json).toEqual(rdata.slice(0, 3));
                 view.delete();
                 table.delete();
             });
@@ -210,7 +211,7 @@ module.exports = perspective => {
                     filter: [["x", ">", 1], ["x", "<", 4]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(1, 3)).toEqual(json);
+                expect(json).toEqual(rdata.slice(1, 3));
                 view.delete();
                 table.delete();
             });
@@ -222,7 +223,7 @@ module.exports = perspective => {
                     filter: [["y", "contains", "a"], ["y", "contains", "b"]]
                 });
                 let json = await view.to_json();
-                expect(rdata.slice(0, 2)).toEqual(json);
+                expect(json).toEqual(rdata.slice(0, 2));
                 view.delete();
                 table.delete();
             });
@@ -261,7 +262,7 @@ module.exports = perspective => {
                 });
                 var answer = [{x: 3.5, y: 1}, {x: 4.5, y: 2}];
                 let result = await view.to_json();
-                expect(answer).toEqual(result);
+                expect(result).toEqual(answer);
                 view.delete();
                 table.delete();
             });
@@ -275,7 +276,7 @@ module.exports = perspective => {
                 });
                 var answer = dataSet;
                 let result = await view.to_json();
-                expect(answer).toEqual(result);
+                expect(result).toEqual(answer);
                 view.delete();
                 table.delete();
             });

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -34,7 +34,7 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], x: 10}, {__ROW_PATH__: [false], x: 6}, {__ROW_PATH__: [true], x: 4}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -47,7 +47,7 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], x: 10}, {__ROW_PATH__: [false], x: 6}, {__ROW_PATH__: [true], x: 4}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -60,7 +60,7 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], x: 2.5, "x|y": 2.8333333333333335}, {__ROW_PATH__: [false], x: 3, "x|y": 3.3333333333333335}, {__ROW_PATH__: [true], x: 2, "x|y": 2.3333333333333335}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -73,7 +73,7 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], x: 2.5}, {__ROW_PATH__: [false], x: 3}, {__ROW_PATH__: [true], x: 2}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -86,7 +86,7 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], x: 1}, {__ROW_PATH__: [false], x: 2}, {__ROW_PATH__: [true], x: 1}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -99,7 +99,7 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], x: 4}, {__ROW_PATH__: [false], x: 4}, {__ROW_PATH__: [true], x: 3}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -112,12 +112,12 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [false], x: 4}, {__ROW_PATH__: [true], x: 3}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
 
             table.update([{x: 1, y: "c", z: true}, {x: 2, y: "d", z: false}]);
             var answerAfterUpdate = [{__ROW_PATH__: [], x: 1}, {__ROW_PATH__: [false], x: 2}, {__ROW_PATH__: [true], x: 1}];
             let result2 = await view.to_json();
-            expect(answerAfterUpdate).toEqual(result2);
+            expect(result2).toEqual(answerAfterUpdate);
             view.delete();
             table.delete();
         });
@@ -210,7 +210,7 @@ module.exports = perspective => {
                 {__ROW_PATH__: [2, "c"], x: 4}
             ];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -236,7 +236,7 @@ module.exports = perspective => {
             });
             var answer = [{__ROW_PATH__: [], y: (1 * 200 + 2 * 100) / (1 + 2)}, {__ROW_PATH__: ["a"], y: (1 * 200 + 2 * 100) / (1 + 2)}];
             let result = await view.to_json();
-            expect(answer).toEqual(result);
+            expect(result).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -279,7 +279,7 @@ module.exports = perspective => {
             table.update(rec2);
             let result2 = await view.to_json();
             var answer = [{__ROW_PATH__: [], pos: 600}, {__ROW_PATH__: [1], pos: 100}, {__ROW_PATH__: [2], pos: 200}, {__ROW_PATH__: [3], pos: 300}];
-            expect(answer).toEqual(result2);
+            expect(result2).toEqual(answer);
             view.delete();
             table.delete();
         });
@@ -434,7 +434,7 @@ module.exports = perspective => {
                 column_pivot: ["y"]
             });
             let result2 = await view.schema();
-            expect(meta).toEqual(result2);
+            expect(result2).toEqual(meta);
             view.delete();
             table.delete();
         });
@@ -487,7 +487,7 @@ module.exports = perspective => {
                 {"a|x": null, "a|y": null, "a|z": null, "b|x": null, "b|y": null, "b|z": null, "c|x": null, "c|y": null, "c|z": null, "d|x": 4, "d|y": "d", "d|z": false}
             ];
             let result2 = await view.to_json();
-            expect(answer).toEqual(result2);
+            expect(result2).toEqual(answer);
             view.delete();
             table.delete();
         });

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -52,18 +52,18 @@ module.exports = perspective => {
             table.remove([1, 2]);
             let result = await view.to_json();
             expect(result.length).toEqual(2);
-            expect(data.slice(2, 4)).toEqual(result);
+            expect(result).toEqual(data.slice(2, 4));
             view.delete();
             table.delete();
         });
 
-        it("after a regular data load`", async function() {
+        it("after a regular data load", async function() {
             var table = perspective.table(data, {index: "x"});
             var view = table.view();
             table.remove([1, 2]);
             let result = await view.to_json();
             expect(result.length).toEqual(2);
-            expect(data.slice(2, 4)).toEqual(result);
+            expect(result).toEqual(data.slice(2, 4));
             view.delete();
             table.delete();
         });
@@ -113,7 +113,7 @@ module.exports = perspective => {
             table.update(data);
             var view = table.view();
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -169,7 +169,7 @@ module.exports = perspective => {
             updater(data);
             let view = table.view();
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -180,7 +180,7 @@ module.exports = perspective => {
             table.update(data);
             var view = table.view();
             let result = await view.to_json();
-            expect(data.concat(data)).toEqual(result);
+            expect(result).toEqual(data.concat(data));
             view.delete();
             table.delete();
         });
@@ -190,7 +190,7 @@ module.exports = perspective => {
             var view = table.view();
             table.update(data);
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -234,7 +234,7 @@ module.exports = perspective => {
             var table = perspective.table(meta);
             var view = table.view();
             view.on_update(function(new_data) {
-                expect(data).toEqual(new_data);
+                expect(new_data).toEqual(data);
                 view.delete();
                 table.delete();
                 done();
@@ -267,7 +267,7 @@ module.exports = perspective => {
             view1.on_update(async function(x) {
                 table2.update(x);
                 let result = await view2.to_json();
-                expect(data).toEqual(result);
+                expect(result).toEqual(data);
                 view1.delete();
                 view2.delete();
                 table1.delete();
@@ -288,7 +288,7 @@ module.exports = perspective => {
             view1.on_update(async function(x) {
                 table2.update(x);
                 let result = await view2.to_json();
-                expect(data.concat(data)).toEqual(result);
+                expect(result).toEqual(data.concat(data));
                 view1.delete();
                 view2.delete();
                 table1.delete();
@@ -304,7 +304,7 @@ module.exports = perspective => {
             var table = perspective.table(data, {limit: 2});
             var view = table.view();
             let result = await view.to_json();
-            expect(data.slice(2)).toEqual(result);
+            expect(result).toEqual(data.slice(2));
             view.delete();
             table.delete();
         });
@@ -314,12 +314,12 @@ module.exports = perspective => {
             table.update(data);
             var view = table.view();
             let result = await view.to_json();
-            expect(
+            expect(result).toEqual(
                 data
                     .slice(1)
                     .concat(data.slice(3, 4))
                     .concat(data.slice(0, 1))
-            ).toEqual(result);
+            );
             view.delete();
             table.delete();
         });
@@ -331,7 +331,7 @@ module.exports = perspective => {
             var view = table.view();
             table.update(data);
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -341,7 +341,7 @@ module.exports = perspective => {
             var view = table.view();
             table.update(data);
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -350,7 +350,7 @@ module.exports = perspective => {
             var table = perspective.table(arrow.slice(), {index: "i64"});
             var view = table.view();
             let result = await view.to_json();
-            expect(arrow_result).toEqual(result);
+            expect(result).toEqual(arrow_result);
             view.delete();
             table.delete();
         });
@@ -359,7 +359,7 @@ module.exports = perspective => {
             var table = perspective.table(arrow.slice(), {index: "char"});
             var view = table.view();
             let result = await view.to_json();
-            expect(arrow_indexed_result).toEqual(result);
+            expect(result).toEqual(arrow_indexed_result);
             view.delete();
             table.delete();
         });
@@ -380,7 +380,7 @@ module.exports = perspective => {
             table.update(data);
             table.update(data);
             let result = await view.to_json();
-            expect(data).toEqual(result);
+            expect(result).toEqual(data);
             view.delete();
             table.delete();
         });
@@ -391,7 +391,7 @@ module.exports = perspective => {
             table.update(data);
             table.update(data_2);
             let result = await view.to_json();
-            expect(data.slice(0, 2).concat(data_2)).toEqual(result);
+            expect(result).toEqual(data.slice(0, 2).concat(data_2));
             view.delete();
             table.delete();
         });
@@ -403,7 +403,7 @@ module.exports = perspective => {
             view.on_update(async function(new_data) {
                 expect(data_2).toEqual(new_data);
                 let json = await view.to_json();
-                expect(data.slice(0, 2).concat(data_2)).toEqual(json);
+                expect(json).toEqual(data.slice(0, 2).concat(data_2));
                 view.delete();
                 table.delete();
                 done();
@@ -418,7 +418,7 @@ module.exports = perspective => {
             view.on_update(async function(new_data) {
                 expect(data_2).toEqual(new_data);
                 let json = await view.to_json();
-                expect(data.slice(0, 2).concat(data_2)).toEqual(json);
+                expect(json).toEqual(data.slice(0, 2).concat(data_2));
                 view.delete();
                 table.delete();
                 done();
@@ -445,7 +445,7 @@ module.exports = perspective => {
                 {__ROW_PATH__: [true, "a"]},
                 {__ROW_PATH__: [true, "c"]}
             ];
-            expect(expected).toEqual(result);
+            expect(result).toEqual(expected);
             view.delete();
             table.delete();
         });
@@ -595,7 +595,7 @@ module.exports = perspective => {
                 }
             });
             let result = await view.to_json();
-            expect(data.slice(0, 2)).toEqual(result);
+            expect(result).toEqual(data.slice(0, 2));
             view.delete();
             table.delete();
         });
@@ -608,7 +608,7 @@ module.exports = perspective => {
                 }
             });
             let result = await view.to_json();
-            expect(data.slice(2)).toEqual(result);
+            expect(result).toEqual(data.slice(2));
             view.delete();
             table.delete();
         });
@@ -622,7 +622,7 @@ module.exports = perspective => {
             });
             var result2 = _.map(data, x => _.pick(x, "x", "y"));
             let result = await view.to_json();
-            expect(result2).toEqual(result);
+            expect(result).toEqual(result2);
             view.delete();
             table.delete();
         });

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -19,17 +19,29 @@ const IS_WRITE = args.indexOf("--write") !== -1 || process.env.WRITE_TESTS;
 const IS_DOCKER = args.indexOf("--docker") !== -1 || process.env.PSP_DOCKER;
 
 function jest() {
-    let cmd = "node_modules/.bin/jest --color --silent";
+    let cmd = "node_modules/.bin/jest --color";
+
     if (args.indexOf("--saturate") > -1) {
         console.log("-- Running the test suite in saturate mode");
         cmd = "PSP_SATURATE=1 " + cmd;
     }
+
+    if (args.indexOf("--bail") > -1) {
+        cmd += " --bail";
+    }
+
+    if (args.indexOf("--debug") > -1) {
+        console.log("Running tests in debug mode - all console.log statements are preserved.");
+    } else {
+        cmd += " --silent 2>&1";
+    }
+
     if (args.indexOf("-t") > -1) {
         const regex = args.slice(args.indexOf("-t") + 1).join(" ");
         console.log(`-- Qualifying search '${regex}'`);
         cmd += ` -t '${regex}'`;
     }
-    cmd += " 2>&1";
+
     return cmd;
 }
 


### PR DESCRIPTION
- Add the following flags to the test script:
  - `--bail`: quits after the first test suite failure
  - `--debug`: preserves all console statements
- Make order of `expect().toEqual()` in Perspective.js tests consistent.