### PR TITLE
Correctly type parse numbers wrapped in strings

### DIFF
--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -36,6 +36,10 @@ var data_7 = {
     z: [true, false, true, false]
 };
 
+var int_in_string = [{a: "1"}, {a: "2"}, {a: "12345"}];
+
+var float_in_string = [{a: "1.5"}, {a: "2.5"}, {a: "12345.56789"}];
+
 var meta_3 = {
     w: "float",
     x: "integer",
@@ -463,6 +467,24 @@ module.exports = perspective => {
             var view = table.view();
             let result = await view.to_json();
             expect(result).toEqual(data_3);
+            view.delete();
+            table.delete();
+        });
+
+        it("Infers ints wrapped in strings", async function() {
+            var table = perspective.table(int_in_string);
+            var view = table.view();
+            let result = await view.schema();
+            expect(result).toEqual({a: "integer"});
+            view.delete();
+            table.delete();
+        });
+
+        it("Infers floats wrapped in strings", async function() {
+            var table = perspective.table(float_in_string);
+            var view = table.view();
+            let result = await view.schema();
+            expect(result).toEqual({a: "float"});
             view.delete();
             table.delete();
         });

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -935,9 +935,7 @@ column_names(val data, std::int32_t format) {
     if (format == 0) {
         std::int32_t max_check = 50;
         val data_names = Object.call<val>("keys", data[0]);
-        std::int32_t check_index = val::global("Math")
-                                       .call<val>("min", val(max_check), val(data["length"]))
-                                       .as<std::int32_t>();
+        std::int32_t check_index = std::min(max_check, data["length"].as<std::int32_t>());
 
         for (auto ix = 0; ix < check_index; ix++) {
             val next = Object.call<val>("keys", data[ix]);


### PR DESCRIPTION
- Fix issue #368 in data parser
- Use `std::min` instead of embind to JS Math module