### PR TITLE
Empty filters

### DIFF
--- a/packages/perspective-viewer/src/js/viewer/perspective_element.js
+++ b/packages/perspective-viewer/src/js/viewer/perspective_element.js
@@ -218,7 +218,7 @@ export class PerspectiveElement extends StateElement {
             const exclamation = node.shadowRoot.getElementById("row_exclamation");
             const {operator, operand} = JSON.parse(node.getAttribute("filter"));
             const filter = [node.getAttribute("name"), operator, operand];
-            if (await this._table.is_valid_filter(filter)) {
+            if (await this._table.is_valid_filter(filter) && operand !== "") {
                 filters.push(filter);
                 node.title = "";
                 operandNode.style.borderColor = "";

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -860,7 +860,7 @@ export default function(Module) {
         const schema = this._schema();
         const isDateFilter = this._is_date_filter(schema);
         const value = isDateFilter(filter[0]) ? new DateParser().parse(filter[2]) : filter[2];
-        return typeof value !== "undefined" && value !== null && value !== "";
+        return typeof value !== "undefined" && value !== null;
     };
 
     /**

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -280,20 +280,6 @@ module.exports = perspective => {
                 view.delete();
                 table.delete();
             });
-
-            it('x == ""', async function() {
-                var table = perspective.table({x: "float", y: "integer"});
-                const dataSet = [{x: 3.5, y: 1}, {x: 2.5, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4.5, y: 2}, {x: null, y: 2}];
-                table.update(dataSet);
-                var view = table.view({
-                    filter: [["x", "==", ""]]
-                });
-                var answer = dataSet;
-                let result = await view.to_json();
-                expect(answer).toEqual(result);
-                view.delete();
-                table.delete();
-            });
         });
 
         describe("is_valid_filter", function() {
@@ -318,7 +304,7 @@ module.exports = perspective => {
             it('x == ""', async function() {
                 var table = perspective.table(data);
                 let isValid = await table.is_valid_filter(["x", "==", ""]);
-                expect(isValid).toBeFalsy();
+                expect(isValid).toBeTruthy();
                 table.delete();
             });
             it("valid date", async function() {


### PR DESCRIPTION
#349 #375 Prior to my pull request for invalid filters, I've had a slight re-think of my implementation. My implementation resulted in empty strings being invalid filter operands. Although this makes sense for the viewer component, it doesn't seem to be appropriate for those using Perspective without the viewer. Therefore, I've pulled the check for empty strings into the viewer and updated the tests as necessary.