### PR TITLE
Remove cross /src imports in packages

### DIFF
--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -43,6 +43,7 @@
         "@jpmorganchase/perspective-viewer": "^0.2.12",
         "babel-runtime": "^6.26.0",
         "chroma-js": "^1.3.4",
+        "detectie": "1.0.0",
         "gradient-parser": "0.1.5",
         "highcharts": "6.1.0",
         "highcharts-grouped-categories": "1.1.2",

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -17,7 +17,7 @@ import {color_axis} from "./color_axis.js";
 import {make_tree_data, make_y_data, make_xy_data, make_xyz_data, make_xy_column_data} from "./series.js";
 import {set_boost, set_category_axis, set_both_axis, default_config, set_tick_size} from "./config.js";
 import {bindTemplate} from "@jpmorganchase/perspective-viewer/src/js/utils";
-import {detectIE} from "@jpmorganchase/perspective/src/js/utils";
+import detectIE from "detectie";
 
 export const PRIVATE = Symbol("Highcharts private");
 

--- a/packages/perspective-viewer-highcharts/src/js/series.js
+++ b/packages/perspective-viewer-highcharts/src/js/series.js
@@ -7,7 +7,6 @@
  *
  */
 
-// import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
 const COLUMN_SEPARATOR_STRING = "|";
 
 function row_to_series(series, sname, gname) {

--- a/packages/perspective-viewer-highcharts/src/js/series.js
+++ b/packages/perspective-viewer-highcharts/src/js/series.js
@@ -7,7 +7,8 @@
  *
  */
 
-import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
+// import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
+const COLUMN_SEPARATOR_STRING = "|";
 
 function row_to_series(series, sname, gname) {
     let s;

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -7,7 +7,6 @@
  *
  */
 
-// import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
 const COLUMN_SEPARATOR_STRING = "|";
 
 const TREE_COLUMN_INDEX = require("fin-hypergrid/src/behaviors/Behavior").prototype.treeColumnIndex;

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -7,7 +7,8 @@
  *
  */
 
-const {COLUMN_SEPARATOR_STRING} = require("@jpmorganchase/perspective/src/js/defaults.js");
+// import {COLUMN_SEPARATOR_STRING} from "@jpmorganchase/perspective/src/js/defaults.js";
+const COLUMN_SEPARATOR_STRING = "|";
 
 const TREE_COLUMN_INDEX = require("fin-hypergrid/src/behaviors/Behavior").prototype.treeColumnIndex;
 

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -49,6 +49,7 @@
         "babel-polyfill": "^6.26.0",
         "babel-runtime": "^6.26.0",
         "d3-array": "^1.2.1",
+        "detectie": "1.0.0",
         "mobile-drag-drop": "^2.2.0",
         "underscore": "^1.8.3"
     }

--- a/packages/perspective-viewer/src/js/utils.js
+++ b/packages/perspective-viewer/src/js/utils.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {detectIE} from "@jpmorganchase/perspective/src/js/utils.js";
+import detectIE from "detectie";
 
 /**
  * Instantiate a Template DOM object from an HTML text string.

--- a/packages/perspective-viewer/src/js/viewer/dragdrop.js
+++ b/packages/perspective-viewer/src/js/viewer/dragdrop.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {detectIE} from "@jpmorganchase/perspective/src/js/utils.js";
+import detectIE from "detectie";
 
 function calc_index(event) {
     if (this._active_columns.children.length == 0) {

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -67,6 +67,7 @@
         "core-js": "^2.5.7",
         "css-loader": "^0.28.7",
         "d3-array": "^1.2.1",
+        "detectie": "1.0.0",
         "extract-text-webpack-plugin": "^3.0.2",
         "file-loader": "^2.0.0",
         "flatbuffers": "^1.10.2",

--- a/packages/perspective/src/js/utils.js
+++ b/packages/perspective/src/js/utils.js
@@ -64,24 +64,7 @@ export function detectNode() {
  * -------
  * True if the current script is running in Internet Explorer.
  */
-export function detectIE() {
-    if (typeof window === "undefined") return false;
-    var ua = window.navigator.userAgent;
-    var msie = ua.indexOf("MSIE ");
-    if (msie > 0) {
-        return parseInt(ua.substring(msie + 5, ua.indexOf(".", msie)), 10);
-    }
-    var trident = ua.indexOf("Trident/");
-    if (trident > 0) {
-        var rv = ua.indexOf("rv:");
-        return parseInt(ua.substring(rv + 3, ua.indexOf(".", rv)), 10);
-    }
-    var edge = ua.indexOf("Edge/");
-    if (edge > 0) {
-        return parseInt(ua.substring(edge + 5, ua.indexOf(".", edge)), 10);
-    }
-    return false;
-}
+export const detectIE = require("detectie");
 
 /**
  * Detect Chrome.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3931,6 +3931,11 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detectie@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detectie/-/detectie-1.0.0.tgz#66b2cae2236d4d29ef71161180957bf89fbe535d"
+  integrity sha1-ZrLK4iNtTSnvcRYRgJV7+J++U10=
+
 detective@^4.0.0:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/detective/-/detective-4.7.1.tgz#0eca7314338442febb6d65da54c10bb1c82b246e"


### PR DESCRIPTION
Remove the cross imported files from `/src` directories in perspective packages. Useful so that we can build self contained bundles without needing to reach into packages. 

1. Added a comment for usages of `COLUMN_SEPARATOR_STRING` and replaced with constant. 
2. Replaced `detectIE` with external `detectie` package. 