### PR TITLE
Output CJS module bundles for perspective-viewer packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,7 @@ website/static/css/material.dark.css
 
 # CPP Compile
 /src/include/boost
+cjs
 obj
-packages/perspective/es5
 cppbuild
 .coverage

--- a/packages/perspective-viewer-highcharts/package.json
+++ b/packages/perspective-viewer-highcharts/package.json
@@ -2,9 +2,10 @@
     "name": "@jpmorganchase/perspective-viewer-highcharts",
     "version": "0.2.12",
     "description": "Perspective.js",
-    "main": "src/js/highcharts.js",
+    "main": "cjs/perspective-viewer-plugin-highcharts.js",
     "files": [
         "build/**/*",
+        "cjs/*",
         "src/**/*",
         "babel.config.js"
     ],
@@ -12,7 +13,9 @@
         "bench": "npm-run-all bench:build bench:run",
         "bench:build": "echo \"No Benchmarks\"",
         "bench:run": "echo \"No Benchmarks\"",
-        "build": "webpack --color --config src/config/highcharts.plugin.config.js",
+        "build:cjs": "webpack --color --config src/config/highcharts.plugin.cjs.config.js",
+        "build:umd": "webpack --color --config src/config/highcharts.plugin.config.js",
+        "build": "npm-run-all build:*",
         "test:build": "cp test/html/* build",
         "watch": "webpack --color --watch --config src/config/highcharts.plugin.config.js",
         "test:run": "jest --silent --color 2>&1",

--- a/packages/perspective-viewer-highcharts/src/config/highcharts.plugin.cjs.config.js
+++ b/packages/perspective-viewer-highcharts/src/config/highcharts.plugin.cjs.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+const common = require("@jpmorganchase/perspective/src/config/common.config.js");
+const {dependencies} = require("../../package.json");
+
+const externals = Object.keys(dependencies).map(external => new RegExp(`^${external}.*$`));
+
+module.exports = Object.assign({}, common({no_minify: true}), {
+    devtool: false,
+    entry: "./src/js/highcharts.js",
+    output: {
+        filename: "perspective-viewer-plugin-highcharts.js",
+        libraryTarget: "commonjs2",
+        path: path.resolve(__dirname, "../../cjs")
+    },
+    externals: [
+        function(context, request, callback) {
+            for (let external of externals) {
+                if (external.test(request)) {
+                    return callback(null, "commonjs " + request);
+                }
+            }
+            callback();
+        }
+    ]
+});

--- a/packages/perspective-viewer-hypergrid/package.json
+++ b/packages/perspective-viewer-hypergrid/package.json
@@ -2,9 +2,10 @@
     "name": "@jpmorganchase/perspective-viewer-hypergrid",
     "version": "0.2.12",
     "description": "Perspective.js",
-    "main": "src/js/hypergrid.js",
+    "main": "cjs/perspective-viewer-plugin-hypergrid.js",
     "files": [
         "build/**/*",
+        "cjs/*",
         "src/**/*",
         "babel.config.js"
     ],
@@ -12,7 +13,9 @@
         "bench": "npm-run-all bench:build bench:run",
         "bench:build": "echo \"No Benchmarks\"",
         "bench:run": "echo \"No Benchmarks\"",
-        "build": "webpack --color --config src/config/hypergrid.plugin.config.js",
+        "build:cjs": "webpack --color --config src/config/hypergrid.plugin.cjs.config.js",
+        "build:umd": "webpack --color --config src/config/hypergrid.plugin.config.js",
+        "build": "npm-run-all build:*",
         "test:build": "cp test/html/* build",
         "test:run": "jest --silent --color",
         "test": "npm-run-all test:build test:run",

--- a/packages/perspective-viewer-hypergrid/src/config/hypergrid.plugin.cjs.config.js
+++ b/packages/perspective-viewer-hypergrid/src/config/hypergrid.plugin.cjs.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+const common = require("@jpmorganchase/perspective/src/config/common.config.js");
+const {dependencies} = require("../../package.json");
+
+const externals = Object.keys(dependencies).map(external => new RegExp(`^${external}.*$`));
+
+module.exports = Object.assign({}, common({no_minify: true}), {
+    devtool: false,
+    entry: "./src/js/hypergrid.js",
+    output: {
+        filename: "perspective-viewer-plugin-hypergrid.js",
+        libraryTarget: "commonjs2",
+        path: path.resolve(__dirname, "../../cjs")
+    },
+    externals: [
+        function(context, request, callback) {
+            for (let external of externals) {
+                if (external.test(request)) {
+                    return callback(null, "commonjs " + request);
+                }
+            }
+            callback();
+        }
+    ]
+});

--- a/packages/perspective-viewer/package.json
+++ b/packages/perspective-viewer/package.json
@@ -2,9 +2,10 @@
     "name": "@jpmorganchase/perspective-viewer",
     "version": "0.2.12",
     "description": "Perspective.js",
-    "main": "src/js/viewer.js",
+    "main": "cjs/perspective-viewer.js",
     "files": [
         "build/**/*",
+        "cjs/*",
         "src/**/*",
         "babel.config.js"
     ],
@@ -12,7 +13,8 @@
         "bench": "npm-run-all bench:build bench:run",
         "bench:build": "echo \"No Benchmarks\"",
         "bench:run": "echo \"No Benchmarks\"",
-        "build:webpack": "webpack --color --config src/config/view.config.js",
+        "build:cjs": "webpack --color --config src/config/view.cjs.config.js",
+        "build:umd": "webpack --color --config src/config/view.config.js",
         "build:themes": "webpack --color --config src/config/themes.config.js && rm build/__themes.js",
         "build": "npm-run-all build:*",
         "watch": "webpack --color --watch --config src/config/view.config.js",

--- a/packages/perspective-viewer/src/config/view.cjs.config.js
+++ b/packages/perspective-viewer/src/config/view.cjs.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+const common = require("@jpmorganchase/perspective/src/config/common.config.js");
+const {dependencies} = require("../../package.json");
+
+const externals = Object.keys(dependencies).map(external => new RegExp(`^${external}.*$`));
+
+module.exports = Object.assign({}, common({no_minify: true}), {
+    devtool: false,
+    entry: "./src/js/viewer.js",
+    output: {
+        filename: "perspective-viewer.js",
+        libraryTarget: "commonjs2",
+        path: path.resolve(__dirname, "../../cjs")
+    },
+    externals: [
+        function(context, request, callback) {
+            for (let external of externals) {
+                if (external.test(request)) {
+                    return callback(null, "commonjs " + request);
+                }
+            }
+            callback();
+        }
+    ]
+});


### PR DESCRIPTION
Output a `slim` version of the perspective viewer packages which is targeted when consuming the package from a module bundler (e.g. webpack, rollup, etc.)

1. Reduce the scope creep of #378 
2. unminified, precompiled assets, will be quicker for Webpack to parse and compile than the UMD builds. 
3. It will prevent duplication of dependencies of `perspective-*` packages when built together - leading to smaller bundle sizes for consumers. 