### PR TITLE
Date parsing bug

### DIFF
--- a/packages/perspective/src/js/DataAccessor/DateParser.js
+++ b/packages/perspective/src/js/DataAccessor/DateParser.js
@@ -40,7 +40,10 @@ export class DateParser {
             return null;
         } else {
             let val = input;
-            if (typeof val === "string") {
+            const type = typeof val;
+            if (val.getMonth) {
+                return val;
+            } else if (type === "string") {
                 val = moment(input, this.date_types, true);
                 if (!val.isValid() || this.date_types.length === 0) {
                     for (let candidate of this.date_candidates) {
@@ -55,8 +58,10 @@ export class DateParser {
                     return null;
                 }
                 return val.toDate();
+            } else if (type === "number") {
+                return new Date(val);
             }
-            return val;
+            throw new Error(`Unparseable date ${val}`);
         }
     }
 }

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -602,6 +602,16 @@ module.exports = perspective => {
             table.delete();
         });
 
+        it("Handles datetime values with mixed formats", async function() {
+            var table = perspective.table({datetime: "datetime"});
+            table.update([{datetime: new Date(1549257586108)}, {datetime: "2019-01-30"}, {datetime: 11}]);
+            let view = table.view();
+            let result = await view.to_json();
+            expect(result).toEqual([{datetime: 1549257586108}, {datetime: 1548806400000}, {datetime: 11}]);
+            view.delete();
+            table.delete();
+        });
+
         it("Handles date values", async function() {
             var table = perspective.table({v: "date"});
             table.update(data_4);

--- a/src/cpp/context_grouped_pkey.cpp
+++ b/src/cpp/context_grouped_pkey.cpp
@@ -32,7 +32,7 @@ t_ctx_grouped_pkey::t_ctx_grouped_pkey()
 t_ctx_grouped_pkey::t_ctx_grouped_pkey(t_schema schema, t_config config)
 	: m_depth(0),
 	m_depth_set(false) {
-	PSP_COMPLAIN_AND_ABORT('Not Implemented');
+	PSP_COMPLAIN_AND_ABORT("Not Implemented");
 }
 
 t_ctx_grouped_pkey::~t_ctx_grouped_pkey() {}


### PR DESCRIPTION
Fixes a `date`/`datetime` parsing issue, which caused such columns with mixed string/integer to fail.  This should really not be a real use case - but due to the optimized parse code path, failures in this case resulted in unintelligible emscripten error messages, which is also resolved by this PR.