### PR TITLE
`null` category axis fix

### DIFF
--- a/packages/perspective-viewer-highcharts/src/js/series.js
+++ b/packages/perspective-viewer-highcharts/src/js/series.js
@@ -48,6 +48,14 @@ function column_to_series(data, sname, gname) {
     return s;
 }
 
+function replace_null(str) {
+    if (str === null) {
+        return "-";
+    } else {
+        return "" + str;
+    }
+}
+
 // Row-based axis generator
 class TreeAxisIterator {
     constructor(depth, json) {
@@ -85,7 +93,7 @@ class TreeAxisIterator {
             if (path.length > 0 && path.length < this.depth) {
                 label = this.add_label(path);
             } else if (path.length >= this.depth) {
-                label.categories.push(path[path.length - 1]);
+                label.categories.push(replace_null(path[path.length - 1]));
                 yield row;
             }
         }
@@ -132,7 +140,7 @@ class ChartAxis {
             if (path.length > 0 && path.length < this.depth) {
                 label = this.add_label(path);
             } else if (path.length >= this.depth) {
-                label.categories.push(path[path.length - 1]);
+                label.categories.push(replace_null(path[path.length - 1]));
                 continue;
             }
         }
@@ -252,11 +260,7 @@ class TickClean {
         if (this.type === "string") {
             if (!(val in this.dict)) {
                 this.dict[val] = Object.keys(this.dict).length;
-                if (val === null) {
-                    this.names.push("-");
-                } else {
-                    this.names.push(val);
-                }
+                this.names.push(replace_null(val));
             }
             return this.dict[val];
         } else if (val === undefined || val === "" || isNaN(val)) {
@@ -583,7 +587,7 @@ class TreeIterator extends TreeAxisIterator {
             if (path.length > 0 && path.length < this.depth) {
                 label = this.add_label(path);
             } else if (path.length >= this.depth) {
-                label.categories.push(path[path.length - 1]);
+                label.categories.push(replace_null(path[path.length - 1]));
             }
             yield row;
         }

--- a/packages/perspective-viewer-highcharts/test/html/null.html
+++ b/packages/perspective-viewer-highcharts/test/html/null.html
@@ -1,0 +1,49 @@
+<!--
+   
+   Copyright (c) 2017, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+    <head>
+
+        <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
+        <script src="perspective.view.js"></script>
+        <script src="highcharts.plugin.js"></script>
+
+        <link rel='stylesheet' href="demo.css">
+
+    </head>
+    <body>
+
+        <perspective-viewer
+            view='y_bar'
+            row-pivots='["x"]'
+            columns='["y"]'>
+  
+        </perspective-viewer>
+
+        <script>
+
+            document.getElementsByTagName('perspective-viewer')[0].load([
+                {x: "a", y: 2},
+                {x: "a", y: 4},
+                {x: "a", y: 1},
+                {x: "a", y: 0},
+                {x: "b", y: 2},
+                {x: "b", y: 2},
+                {x: "b", y: 6},
+                {x: "b", y: 1},
+                {x: "c", y: 1},
+                {x: "c", y: 1},
+                {x: "c", y: 1}
+            ]); 
+
+        </script>
+
+    </body>
+</html>

--- a/packages/perspective-viewer-highcharts/test/js/bar.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/bar.spec.js
@@ -58,6 +58,19 @@ utils.with_server({}, () => {
         {reload_page: false, root: path.join(__dirname, "..", "..")}
     );
 
+    describe.page("null.html", () => {
+        test.capture(
+            "should handle null categories in a pivot",
+            async page => {
+                await page.waitForSelector("perspective-viewer:not([updating])");
+            },
+            {
+                timeout: 60000,
+                wait_for_update: false
+            }
+        );
+    });
+
     describe.page(
         "render_warning.html",
         () => {

--- a/packages/perspective-viewer-highcharts/test/results/results.json
+++ b/packages/perspective-viewer-highcharts/test/results/results.json
@@ -88,5 +88,6 @@
     "scatter.html/highlights invalid filter.": "07814ed1500d1810d934ca8ac9f07486",
     "line.html/highlights invalid filter.": "1dfcefa55fb5bad1804b1fbb708204de",
     "treemap.html/highlights invalid filter.": "5b36e9d8a49d330118c2d6079262d268",
-    "heatmap.html/highlights invalid filter.": "1d1971aee71f389067e7f3c732d26a5f"
+    "heatmap.html/highlights invalid filter.": "1d1971aee71f389067e7f3c732d26a5f",
+    "null.html/should handle null categories in a pivot": "5574f2c3e83ed24577e5ce72626f175c"
 }


### PR DESCRIPTION
Bar (and some other) charts with `null` values in categories fail to render;  this patch replaces them with the correct display value for null, `-`.