### PR TITLE
String column promotion

### DIFF
--- a/packages/perspective-webpack-plugin/index.js
+++ b/packages/perspective-webpack-plugin/index.js
@@ -90,6 +90,13 @@ class PerspectiveWebpackPlugin {
                 loader: "babel-loader",
                 options: BABEL_CONFIG
             });
+        } else {
+            rules.push({
+                test: /\.js$/,
+                include: this.options.load_path,
+                exclude: /node_modules[/\\](?!\@jpmorganchase)|psp\.(asmjs|async|sync)\.js|perspective\.(asmjs|wasm)\.worker\.js/,
+                loader: "source-map-loader"
+            });
         }
 
         rules.push({

--- a/packages/perspective-webpack-plugin/package.json
+++ b/packages/perspective-webpack-plugin/package.json
@@ -43,6 +43,7 @@
         "html-loader": "^0.5.1",
         "less": "^2.7.2",
         "less-loader": "^4.0.5",
+        "source-map-loader": "^0.2.4",
         "style-loader": "^0.18.2",
         "tslib": "^1.9.3",
         "worker-loader": "^2.0.0"

--- a/packages/perspective-webpack-plugin/src/js/psp-worker-loader.js
+++ b/packages/perspective-webpack-plugin/src/js/psp-worker-loader.js
@@ -33,9 +33,6 @@ const schema = {
 };
 
 exports.default = function loader(content) {
-    if (process.env.PSP_DEBUG && content && content.indexOf("asmjs") > -1) {
-        return "module.exports = function() {};";
-    }
     const options = loaderUtils.getOptions(this) || {};
     validateOptions(schema, options, "File Worker Loader");
     const context = options.context || this.rootContext || (this.options && this.options.context);
@@ -44,6 +41,10 @@ exports.default = function loader(content) {
         content,
         regExp: options.regExp
     });
+
+    if (process.env.PSP_DEBUG && emitPath.indexOf("asmjs") > -1) {
+        return `module.exports = function() {  throw new Error('asm.js disabled in debug mode.'); };`;
+    }
 
     if (!options.compiled) {
         var inputPath = this.resourcePath;

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -20,7 +20,7 @@
         "prebuild": "mkdir -p build && mkdir -p obj",
         "cpp": "npm-run-all build:cpp test:cpp",
         "build": "npm-run-all build:babel build:webpack",
-        "build:babel": "babel src/js --out-dir cjs/js",
+        "build:babel": "babel src/js --source-maps --out-dir cjs/js",
         "build:webpack": "npm-run-all -p build:webpack:*",
         "build:webpack:umd": "webpack --color --config src/config/perspective.config.js",
         "build:webpack:node": "webpack --color --config src/config/perspective.node.config.js",

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -1598,7 +1598,7 @@ export default function(Module) {
             try {
                 pool = new __MODULE__.t_pool();
 
-                [gnode, limit_index] = make_table(data_accessor, pool, gnode, undefined, options.index, options.limit, limit_index, false, false, is_arrow);
+                [gnode, limit_index] = make_table(data_accessor, pool, undefined, undefined, options.index, options.limit, limit_index, false, false, is_arrow);
 
                 return new table(gnode, pool, options.index, undefined, options.limit, limit_index);
             } catch (e) {

--- a/src/cpp/table.cpp
+++ b/src/cpp/table.cpp
@@ -582,7 +582,7 @@ t_table::add_column(const std::string& name, t_dtype dtype, bool status_enabled)
 }
 
 void
-t_table::promote_column(const std::string& name, t_dtype new_dtype, std::int32_t iter_limit) {
+t_table::promote_column(const std::string& name, t_dtype new_dtype, std::int32_t iter_limit, bool fill) {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
 
@@ -594,11 +594,6 @@ t_table::promote_column(const std::string& name, t_dtype new_dtype, std::int32_t
     t_uindex idx = m_schema.get_colidx(name);
     std::shared_ptr<t_column> current_col = m_columns[idx];
 
-    if (new_dtype != DTYPE_FLOAT64 || current_col->get_dtype() != DTYPE_INT32) {
-        std::cout << "Promotion only works for int to float." << std::endl;
-        return;
-    }
-
     // create the new column and copy data
     std::shared_ptr<t_column> promoted_col
         = make_column(name, new_dtype, current_col->is_status_enabled());
@@ -606,10 +601,25 @@ t_table::promote_column(const std::string& name, t_dtype new_dtype, std::int32_t
     promoted_col->reserve(std::max(size(), std::max(static_cast<t_uindex>(8), m_capacity)));
     promoted_col->set_size(size());
 
-    for (auto i = 0; i < iter_limit; ++i) {
-        std::int32_t* val = current_col->get_nth<std::int32_t>(i);
-        double fval = static_cast<double>(*val);
-        promoted_col->set_nth(i, fval);
+    if (fill) {
+        for (auto i = 0; i < iter_limit; ++i) {
+            switch (new_dtype) {
+                case DTYPE_FLOAT64: {
+                    std::int32_t* val = current_col->get_nth<std::int32_t>(i);
+                    double fval = static_cast<double>(*val);
+                    promoted_col->set_nth(i, fval);
+                } break;
+                case DTYPE_STR: {
+                    std::int32_t* val = current_col->get_nth<std::int32_t>(i);
+                    std::string fval = std::to_string(*val);
+                    promoted_col->set_nth(i, fval);
+                } break;
+                default: {
+                    PSP_COMPLAIN_AND_ABORT("Bad promotion");
+                }
+
+            }
+        }
     }
 
     // finally, mutate schema and columns

--- a/src/include/perspective/table.h
+++ b/src/include/perspective/table.h
@@ -124,7 +124,7 @@ public:
     void set_column(t_uindex idx, std::shared_ptr<t_column> col);
     void set_column(const std::string& name, std::shared_ptr<t_column> col);
     t_column* add_column(const std::string& cname, t_dtype dtype, bool status_enabled);
-    void promote_column(const std::string& cname, t_dtype new_dtype, std::int32_t iter_limit);
+    void promote_column(const std::string& cname, t_dtype new_dtype, std::int32_t iter_limit, bool fill);
 
     std::shared_ptr<t_column> make_column(
         const std::string& colname, t_dtype dtype, bool status_enabled);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10482,6 +10482,14 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-loader@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.4.tgz#c18b0dc6e23bf66f6792437557c569a11e072271"
+  integrity sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==
+  dependencies:
+    async "^2.5.0"
+    loader-utils "^1.1.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"


### PR DESCRIPTION
For non-arrow data types, the single pass data loader can now upgrade column types to `string` if they have been mis-inferred as any `Number`.  Also fixes source map generation and debug build bugs encountered during debugging.