### PR TITLE
Allow mac failures on travis, have travis fail fast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js: "8"
 sudo: required
 
 matrix:
+  fast_finish: true
   include:
     - node_js: "8"
       language: node_js
@@ -20,6 +21,11 @@ matrix:
       cache: pip
       services: docker
 
+    - language: c++
+      env: TEST=CPP_OSX
+      os: osx
+
+  allow_failures:
     - language: c++
       env: TEST=CPP_OSX
       os: osx


### PR DESCRIPTION
This PR does two things:
- the Mac image on travis hangs occasionally. Since several of us are developing full time on MacBooks anyway, we can allow this one to fail. 
- Makes travis fail fast, so we dont waste resources when people need to iterate on PRs. 