### PR TITLE
Add `replace()` and `clear()` to table

### DIFF
--- a/packages/perspective-viewer-highcharts/test/js/slow.spec.js
+++ b/packages/perspective-viewer-highcharts/test/js/slow.spec.js
@@ -1,0 +1,23 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
+
+const mutation_tests = require("@jpmorganchase/perspective-viewer/test/js/mutation_tests.js");
+
+utils.with_server({}, () => {
+    describe.page(
+        "line.html",
+        () => {
+            mutation_tests.default();
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
+});

--- a/packages/perspective-viewer-highcharts/test/results/results.json
+++ b/packages/perspective-viewer-highcharts/test/results/results.json
@@ -89,5 +89,6 @@
     "line.html/highlights invalid filter.": "1dfcefa55fb5bad1804b1fbb708204de",
     "treemap.html/highlights invalid filter.": "5b36e9d8a49d330118c2d6079262d268",
     "heatmap.html/highlights invalid filter.": "1d1971aee71f389067e7f3c732d26a5f",
-    "null.html/should handle null categories in a pivot": "5574f2c3e83ed24577e5ce72626f175c"
+    "null.html/should handle null categories in a pivot": "5574f2c3e83ed24577e5ce72626f175c",
+    "line.html/replaces all rows.": "c799ce879d22a1ca89a6266575920d3a"
 }

--- a/packages/perspective-viewer-hypergrid/test/js/slow.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/slow.spec.js
@@ -1,0 +1,23 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("@jpmorganchase/perspective-viewer/test/js/utils.js");
+const path = require("path");
+
+const mutation_tests = require("@jpmorganchase/perspective-viewer/test/js/mutation_tests.js");
+
+utils.with_server({}, () => {
+    describe.page(
+        "superstore.html",
+        () => {
+            mutation_tests.default();
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
+});

--- a/packages/perspective-viewer-hypergrid/test/results/results.json
+++ b/packages/perspective-viewer-hypergrid/test/results/results.json
@@ -17,5 +17,6 @@
     "regressions.html/saving a computed column does not interrupt update rendering": "da13afb4284b9c3da21ed57c6ba69301",
     "empty.html/empty grids do not explode": "423ca653bbcbc21a28029c149a37b8ec",
     "superstore.html/highlights invalid filter.": "e244cca8fc2278cb2477d0a46ab5331f",
-    "superstore.html/handles flush().": "a5d1bad309edf83ceef190dd19d867ec"
+    "superstore.html/handles flush().": "a5d1bad309edf83ceef190dd19d867ec",
+    "superstore.html/replaces all rows.": "2c41d623f03b2417da7b5dcf7f31e364"
 }

--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -499,6 +499,20 @@ class PerspectiveViewer extends ActionElement {
     }
 
     /**
+     * Clears the rows in the current {@link table}.
+     */
+    clear() {
+        this._table.clear();
+    }
+
+    /**
+     * Replaces all rows in the current {@link table}.
+     */
+    replace(data) {
+        this._table.replace(data);
+    }
+
+    /**
      * Reset's this element's view state and attributes to default.  Does not
      * delete this element's `perspective.table` or otherwise modify the data
      * state.

--- a/packages/perspective-viewer/test/js/mutation_tests.js
+++ b/packages/perspective-viewer/test/js/mutation_tests.js
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+exports.default = function() {
+    test.capture("replaces all rows.", async page => {
+        const viewer = await page.$("perspective-viewer");
+        await page.shadow_click("perspective-viewer", "#config_button");
+        const json = await page.evaluate(async element => {
+            let json = await element.view.to_json();
+            return json.slice(10, 20);
+        }, viewer);
+        expect(json.length).toEqual(10);
+        await page.evaluate(
+            async (element, json) => {
+                element.replace(json);
+            },
+            viewer,
+            json
+        );
+        // FIXME This is due to update() not triggering flush() semantics
+        await page.waitFor(1000);
+    });
+};

--- a/packages/perspective-viewer/test/js/simple_tests.js
+++ b/packages/perspective-viewer/test/js/simple_tests.js
@@ -83,23 +83,6 @@ exports.default = function() {
         await page.evaluate(element => element.setAttribute("columns", '["Discount","Profit","Sales","Quantity"]'), viewer);
     });
 
-    test.capture("replaces all rows.", async page => {
-        const viewer = await page.$("perspective-viewer");
-        await page.shadow_click("perspective-viewer", "#config_button");
-        const json = await page.evaluate(async element => {
-            let json = await element.view.to_json();
-            return json.slice(10, 20);
-        }, viewer);
-        expect(json.length).toEqual(10);
-        await page.evaluate(
-            async (element, json) => {
-                element.replace(json);
-            },
-            viewer,
-            json
-        );
-    });
-
     test.skip("pivots by row when drag-and-dropped.", async page => {
         await page.shadow_click("perspective-viewer", "#config_button");
         await drag_drop(page, "perspective-row[name=Category]", "#row_pivots");

--- a/packages/perspective-viewer/test/js/simple_tests.js
+++ b/packages/perspective-viewer/test/js/simple_tests.js
@@ -83,6 +83,23 @@ exports.default = function() {
         await page.evaluate(element => element.setAttribute("columns", '["Discount","Profit","Sales","Quantity"]'), viewer);
     });
 
+    test.capture("replaces all rows.", async page => {
+        const viewer = await page.$("perspective-viewer");
+        await page.shadow_click("perspective-viewer", "#config_button");
+        const json = await page.evaluate(async element => {
+            let json = await element.view.to_json();
+            return json.slice(10, 20);
+        }, viewer);
+        expect(json.length).toEqual(10);
+        await page.evaluate(
+            async (element, json) => {
+                element.replace(json);
+            },
+            viewer,
+            json
+        );
+    });
+
     test.skip("pivots by row when drag-and-dropped.", async page => {
         await page.shadow_click("perspective-viewer", "#config_button");
         await drag_drop(page, "perspective-row[name=Category]", "#row_pivots");

--- a/packages/perspective-viewer/test/js/slow.spec.js
+++ b/packages/perspective-viewer/test/js/slow.spec.js
@@ -1,0 +1,23 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+const utils = require("./utils.js");
+
+const mutation_tests = require("./mutation_tests.js");
+const path = require("path");
+
+utils.with_server({}, () => {
+    describe.page(
+        "superstore.html",
+        () => {
+            mutation_tests.default();
+        },
+        {root: path.join(__dirname, "..", "..")}
+    );
+});

--- a/packages/perspective-viewer/test/results/results.json
+++ b/packages/perspective-viewer/test/results/results.json
@@ -31,5 +31,6 @@
     "superstore.html/adds computed column via attribute": "96016d19e8c94accc24f0d613bdbbab1",
     "superstore.html/saving without parameters should fail as button is disabled.": "a26ce038cea02a8e3e53b7e0b74a204d",
     "superstore.html/saving a duplicate column should fail with error message.": "9d74a59806ad8ec4ab1bcef7c3c94b68",
-    "superstore.html/highlights invalid filter.": "3eadf1175e231c1fbcc2bb9ef10ca6ef"
+    "superstore.html/highlights invalid filter.": "3eadf1175e231c1fbcc2bb9ef10ca6ef",
+    "superstore.html/replaces all rows.": "457b6da4914c99a18f768b27847fc76e"
 }

--- a/packages/perspective/src/js/api.js
+++ b/packages/perspective/src/js/api.js
@@ -173,6 +173,8 @@ table.prototype.columns = async_queue("columns", "table_method");
 
 table.prototype.clear = async_queue("clear", "table_method");
 
+table.prototype.replace = async_queue("replace", "table_method");
+
 table.prototype.delete = async_queue("delete", "table_method");
 
 table.prototype.on_delete = subscribe("on_delete", "table_method", true);

--- a/packages/perspective/src/js/api.js
+++ b/packages/perspective/src/js/api.js
@@ -171,6 +171,8 @@ table.prototype.size = async_queue("size", "table_method");
 
 table.prototype.columns = async_queue("columns", "table_method");
 
+table.prototype.clear = async_queue("clear", "table_method");
+
 table.prototype.delete = async_queue("delete", "table_method");
 
 table.prototype.on_delete = subscribe("on_delete", "table_method", true);

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -689,8 +689,20 @@ export default function(Module) {
         }
     };
 
+    /**
+     * Remove all rows in this {@link table} while preserving the schema and
+     * construction options.
+     */
     table.prototype.clear = function() {
         this.gnode.reset();
+    };
+
+    /**
+     * Replace all rows in this {@link table} the input data.
+     */
+    table.prototype.replace = function(data) {
+        this.gnode.reset();
+        this.update(data);
     };
 
     /**

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -689,6 +689,10 @@ export default function(Module) {
         }
     };
 
+    table.prototype.clear = function() {
+        this.gnode.reset();
+    };
+
     /**
      * Delete this {@link table} and clean up all resources associated with it.
      * Table objects do not stop consuming resources or processing updates when

--- a/packages/perspective/test/js/clear.js
+++ b/packages/perspective/test/js/clear.js
@@ -13,10 +13,26 @@ module.exports = perspective => {
             const table = perspective.table([{x: 1}]);
             const view = table.view();
             let json = await view.to_json();
-            expect(json.length).toEqual(1);
+            expect(json).toHaveLength(1);
             table.clear();
             json = await view.to_json();
-            expect(json.length).toEqual(0);
+            expect(json).toHaveLength(0);
+            view.delete();
+            table.delete();
+        });
+    });
+
+    describe("Replace", function() {
+        it("replaces the rows in the table with the input data", async function() {
+            const table = perspective.table([{x: 1, y: 2}, {x: 3, y: 4}]);
+            const view = table.view();
+            let json = await view.to_json();
+            expect(json).toHaveLength(2);
+            expect(json).toEqual([{x: 1, y: 2}, {x: 3, y: 4}]);
+            table.replace([{x: 5, y: 6}]);
+            json = await view.to_json();
+            expect(json).toHaveLength(1);
+            expect(json).toEqual([{x: 5, y: 6}]);
             view.delete();
             table.delete();
         });

--- a/packages/perspective/test/js/clear.js
+++ b/packages/perspective/test/js/clear.js
@@ -1,0 +1,24 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+module.exports = perspective => {
+    describe("Clear", function() {
+        it("removes the rows from the table", async function() {
+            const table = perspective.table([{x: 1}]);
+            const view = table.view();
+            let json = await view.to_json();
+            expect(json.length).toEqual(1);
+            table.clear();
+            json = await view.to_json();
+            expect(json.length).toEqual(0);
+            view.delete();
+            table.delete();
+        });
+    });
+};

--- a/packages/perspective/test/js/perspective.spec.js
+++ b/packages/perspective/test/js/perspective.spec.js
@@ -18,6 +18,7 @@ if (!process.env.PSP_DEBUG && window.perspective) {
     RUNTIMES.ASMJS = window.perspective;
 }
 
+const clear_tests = require("./clear.js");
 const constructor_tests = require("./constructors.js");
 const pivot_tests = require("./pivots.js");
 const update_tests = require("./updates.js");
@@ -27,6 +28,7 @@ const internal_tests = require("./internal.js");
 describe("perspective.js", function() {
     Object.keys(RUNTIMES).forEach(function(mode) {
         (typeof WebAssembly === "undefined" && mode === "WASM" ? xdescribe : describe)(mode, function() {
+            clear_tests(RUNTIMES[mode]);
             constructor_tests(RUNTIMES[mode]);
             pivot_tests(RUNTIMES[mode]);
             update_tests(RUNTIMES[mode]);

--- a/src/cpp/emscripten.cpp
+++ b/src/cpp/emscripten.cpp
@@ -1585,6 +1585,7 @@ EMSCRIPTEN_BINDINGS(perspective) {
         .function<t_uindex>(
             "get_id", reinterpret_cast<t_uindex (t_gnode::*)() const>(&t_gnode::get_id))
         .function<t_schema>("get_tblschema", &t_gnode::get_tblschema)
+        .function<void>("reset", &t_gnode::reset)
         .function<t_table*>("get_table", &t_gnode::get_table, allow_raw_pointers());
 
     /******************************************************************************


### PR DESCRIPTION
Adds a `replace()` and `clear()` method to the `perspective.table()` API, as well as symmetric methods to the `<perspective-viewer>` web component.