### PR TITLE
Remove inlined webpack loader declaration

### DIFF
--- a/packages/perspective-viewer/src/js/row.js
+++ b/packages/perspective-viewer/src/js/row.js
@@ -10,7 +10,7 @@
 import _ from "lodash";
 
 import Awesomplete from "awesomplete";
-import awesomplete_style from "!!css-loader!awesomplete/awesomplete.css";
+import awesomplete_style from "awesomplete/awesomplete.css";
 
 import {bindTemplate} from "./utils.js";
 

--- a/packages/perspective-webpack-plugin/index.js
+++ b/packages/perspective-webpack-plugin/index.js
@@ -33,10 +33,19 @@ class PerspectiveWebpackPlugin {
     apply(compiler) {
         const rules = [
             {
+                test: /\.css$/,
+                include: this.options.load_path,
+                loader: "css-loader"
+            },
+            {
                 test: /\.less$/,
                 exclude: /themes/,
                 include: this.options.load_path,
-                use: [{loader: "css-loader"}, {loader: "clean-css-loader", options: {level: 2}}, {loader: "less-loader"}]
+                use: [
+                    {loader: "css-loader"}, 
+                    {loader: "clean-css-loader", options: {level: 2}}, 
+                    {loader: "less-loader"}
+                ]
             },
             {
                 test: /\.(html)$/,


### PR DESCRIPTION
Ensure that the webpack loader declarations are in the plugin and configurations so that custom resolution isn't affected when consuming the plugin. 