### PR TITLE
Make sort syntax consistent in tests

### DIFF
--- a/packages/perspective-viewer/test/js/computed_columns.spec.js
+++ b/packages/perspective-viewer/test/js/computed_columns.spec.js
@@ -198,7 +198,7 @@ utils.with_server({}, () => {
             test.capture("sorts by computed column.", async page => {
                 await add_computed_column(page);
                 const viewer = await page.$("perspective-viewer");
-                await page.evaluate(element => element.setAttribute("sort", '["new_cc"]'), viewer);
+                await page.evaluate(element => element.setAttribute("sort", '[["new_cc", "asc"]]'), viewer);
             });
 
             test.capture("filters by computed column.", async page => {

--- a/packages/perspective-viewer/test/js/simple_tests.js
+++ b/packages/perspective-viewer/test/js/simple_tests.js
@@ -50,13 +50,13 @@ exports.default = function() {
         const viewer = await page.$("perspective-viewer");
         await page.shadow_click("perspective-viewer", "#config_button");
         await page.evaluate(element => element.setAttribute("columns", '["Row ID","Quantity"]'), viewer);
-        await page.evaluate(element => element.setAttribute("sort", '["Sales"]'), viewer);
+        await page.evaluate(element => element.setAttribute("sort", '[["Sales", "asc"]]'), viewer);
     });
 
     test.capture("sorts by a numeric column.", async page => {
         const viewer = await page.$("perspective-viewer");
         await page.shadow_click("perspective-viewer", "#config_button");
-        await page.evaluate(element => element.setAttribute("sort", '["Sales"]'), viewer);
+        await page.evaluate(element => element.setAttribute("sort", '[["Sales", "asc"]]'), viewer);
     });
 
     test.capture("filters by a numeric column.", async page => {
@@ -74,7 +74,7 @@ exports.default = function() {
     test.capture("sorts by an alpha column.", async page => {
         const viewer = await page.$("perspective-viewer");
         await page.shadow_click("perspective-viewer", "#config_button");
-        await page.evaluate(element => element.setAttribute("sort", '["State"]'), viewer);
+        await page.evaluate(element => element.setAttribute("sort", '[["State", "asc"]]'), viewer);
     });
 
     test.capture("displays visible columns.", async page => {

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -852,14 +852,16 @@ export default function(Module) {
      * @param {Array<Array<string>>} [config.filter] An Array of Filter configurations to
      * apply.  A filter configuration is an array of 3 elements:  A column name,
      * a supported filter comparison string (e.g. '===', '>'), and a value to compare.
-     * @param {Array<string>} [config.sort] An Array of column names by which to sort.
+     * @param {Array<string>} [config.sort] An Array of Sort configurations to apply.
+     * A sort configuration is an array of 2 elements: A column name, and a sort direction,
+     * which are: "none", "asc", "desc", "col asc", "col desc", "asc abs", "desc abs", "col asc abs", "col desc abs".
      *
      * @example
      * var view = table.view({
      *      row_pivot: ['region'],
      *      aggregate: [{op: 'dominant', column:'region'}],
      *      filter: [['client', 'contains', 'fred']],
-     *      sort: ['value']
+     *      sort: [['value', 'asc']]
      * });
      *
      * @returns {view} A new {@link view} object for the supplied configuration,


### PR DESCRIPTION
Previously we allowed for 2 types of sort syntax to be passed through configs:

- `[["column", "asc"]]`: a 2D array with a column name and a direction string
- `["column"]`: an array of column names

This PR deprecates the latter format in our tests and uses the clearer, first format. 