### PR TITLE
CSV integer parse bug

### DIFF
--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -929,7 +929,7 @@ export default function(Module) {
             if (data[0] === ",") {
                 data = "_" + data;
             }
-            accessor.init(__MODULE__, papaparse.parse(data.trim(), {dynamicTyping: true, header: true}).data);
+            accessor.init(__MODULE__, papaparse.parse(data.trim(), {header: true}).data);
             accessor.names = cols;
             accessor.types = accessor.extract_typevec(types).slice(0, cols.length);
         } else {

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -400,6 +400,18 @@ module.exports = perspective => {
         });
     });
 
+    describe("CSV parsing", function() {
+        it("Does not lose leading 0's when a CSV column is declared as a string", async function() {
+            let table = perspective.table({x: "string", y: "integer"});
+            table.update("x,y\n000123,000123");
+            let view = table.view();
+            let result = await view.to_json();
+            expect(result).toEqual([{x: "000123", y: 123}]);
+            view.delete();
+            table.delete();
+        });
+    });
+
     describe("Constructors", function() {
         it("JSON constructor", async function() {
             var table = perspective.table(data);


### PR DESCRIPTION
Fixes bug which, due to a mis-configured `papaparse`, caused CSV columns declared as strings to sometimes suffer a string->integer->string conversion during parsing, causing leading 0's to be dropped.