### PR TITLE
Add t_data_slice for data output

### DIFF
--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -285,6 +285,8 @@ set (SOURCE_FILES
 	src/cpp/context_two.cpp
 	src/cpp/context_zero.cpp
 	src/cpp/custom_column.cpp
+	src/cpp/data_slice.cpp
+	src/cpp/date.cpp
 	src/cpp/data.cpp
 	src/cpp/date.cpp
 	src/cpp/dense_nodes.cpp

--- a/cpp/perspective/CMakeLists.txt
+++ b/cpp/perspective/CMakeLists.txt
@@ -286,7 +286,6 @@ set (SOURCE_FILES
 	src/cpp/context_zero.cpp
 	src/cpp/custom_column.cpp
 	src/cpp/data_slice.cpp
-	src/cpp/date.cpp
 	src/cpp/data.cpp
 	src/cpp/date.cpp
 	src/cpp/dense_nodes.cpp
@@ -296,6 +295,7 @@ set (SOURCE_FILES
 	src/cpp/extract_aggregate.cpp
 	src/cpp/filter.cpp
 	src/cpp/flat_traversal.cpp
+	src/cpp/get_data_extents.cpp
 	src/cpp/gnode.cpp
 	src/cpp/gnode_state.cpp
 	src/cpp/histogram.cpp

--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -142,9 +142,11 @@ t_config::t_config(const std::vector<std::string>& row_pivots,
 
 t_config::t_config(const std::vector<t_pivot>& row_pivots,
     const std::vector<t_pivot>& col_pivots, const std::vector<t_aggspec>& aggregates,
-    const t_totals totals, t_filter_op combiner, const std::vector<t_fterm>& fterms)
+    const t_totals totals, t_filter_op combiner, const std::vector<t_fterm>& fterms,
+    bool column_only)
     : m_row_pivots(row_pivots)
     , m_col_pivots(col_pivots)
+    , m_column_only(column_only)
     , m_aggregates(aggregates)
     , m_totals(totals)
     , m_combiner(combiner)
@@ -204,8 +206,9 @@ t_config::t_config(const std::vector<std::string>& row_pivots, const t_aggspec& 
 
 t_config::t_config(const std::vector<t_pivot>& row_pivots,
     const std::vector<t_aggspec>& aggregates, t_filter_op combiner,
-    const std::vector<t_fterm>& fterms)
+    const std::vector<t_fterm>& fterms, bool column_only)
     : m_row_pivots(row_pivots)
+    , m_column_only(column_only)
     , m_aggregates(aggregates)
     , m_totals(TOTALS_BEFORE)
     , m_combiner(combiner)
@@ -396,7 +399,7 @@ t_config::get_num_cpivots() const {
 }
 
 bool
-t_config::get_column_only() const {
+t_config::is_column_only() const {
     return m_column_only;
 }
 

--- a/cpp/perspective/src/cpp/context_grouped_pkey.cpp
+++ b/cpp/perspective/src/cpp/context_grouped_pkey.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <perspective/first.h>
-#include <perspective/context_common.h>
+#include <perspective/get_data_extents.h>
 #include <perspective/context_grouped_pkey.h>
 #include <perspective/extract_aggregate.h>
 #include <perspective/filter.h>
@@ -113,11 +113,13 @@ t_ctx_grouped_pkey::get_data(
     t_index start_row, t_index end_row, t_index start_col, t_index end_col) const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-    auto ext = sanitize_get_data_extents(*this, start_row, end_row, start_col, end_col);
+    t_uindex ctx_nrows = get_row_count();
+    t_uindex ncols = get_column_count();
+    auto ext
+        = sanitize_get_data_extents(ctx_nrows, ncols, start_row, end_row, start_col, end_col);
 
     t_index nrows = ext.m_erow - ext.m_srow;
     t_index stride = ext.m_ecol - ext.m_scol;
-    t_uindex ncols = get_column_count();
     std::vector<t_tscalar> values(nrows * stride);
     std::vector<t_tscalar> tmpvalues(nrows * ncols);
 

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -9,7 +9,7 @@
 
 #include <perspective/first.h>
 #include <perspective/sort_specification.h>
-#include <perspective/context_common.h>
+#include <perspective/get_data_extents.h>
 #include <perspective/context_one.h>
 #include <perspective/extract_aggregate.h>
 #include <perspective/filter.h>
@@ -103,12 +103,14 @@ std::vector<t_tscalar>
 t_ctx1::get_data(t_index start_row, t_index end_row, t_index start_col, t_index end_col) const {
     PSP_TRACE_SENTINEL();
     PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
-    auto ext = sanitize_get_data_extents(*this, start_row, end_row, start_col, end_col);
+    t_uindex ctx_nrows = get_row_count();
+    t_uindex ncols = get_column_count();
+    auto ext
+        = sanitize_get_data_extents(ctx_nrows, ncols, start_row, end_row, start_col, end_col);
 
     t_index nrows = ext.m_erow - ext.m_srow;
     t_index stride = ext.m_ecol - ext.m_scol;
 
-    t_uindex ncols = get_column_count();
     std::vector<t_tscalar> tmpvalues(nrows * ncols);
     std::vector<t_tscalar> values(nrows * stride);
 

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <perspective/first.h>
-#include <perspective/context_common.h>
+#include <perspective/get_data_extents.h>
 #include <perspective/context_two.h>
 #include <perspective/extract_aggregate.h>
 #include <perspective/sparse_tree.h>
@@ -194,7 +194,10 @@ t_ctx2::get_ctraversal_indices() const {
 
 std::vector<t_tscalar>
 t_ctx2::get_data(t_index start_row, t_index end_row, t_index start_col, t_index end_col) const {
-    auto ext = sanitize_get_data_extents(*this, start_row, end_row, start_col, end_col);
+    t_uindex ctx_nrows = get_row_count();
+    t_uindex ctx_ncols = get_column_count();
+    auto ext = sanitize_get_data_extents(
+        ctx_nrows, ctx_ncols, start_row, end_row, start_col, end_col);
 
     std::vector<std::pair<t_uindex, t_uindex>> cells;
     for (t_index ridx = ext.m_srow; ridx < ext.m_erow; ++ridx) {
@@ -615,7 +618,10 @@ t_ctx2::get_step_delta(t_index bidx, t_index eidx) {
     rval.columns_changed = true;
     std::vector<t_cellupd>& updvec = rval.cells;
 
-    auto ext = sanitize_get_data_extents(*this, start_row, end_row, start_col, end_col);
+    t_uindex ctx_nrows = get_row_count();
+    t_uindex ctx_ncols = get_column_count();
+    auto ext = sanitize_get_data_extents(
+        ctx_nrows, ctx_ncols, start_row, end_row, start_col, end_col);
 
     std::vector<std::pair<t_uindex, t_uindex>> cells;
 

--- a/cpp/perspective/src/cpp/context_zero.cpp
+++ b/cpp/perspective/src/cpp/context_zero.cpp
@@ -9,7 +9,7 @@
 
 #include <perspective/first.h>
 #include <perspective/context_base.h>
-#include <perspective/context_common.h>
+#include <perspective/get_data_extents.h>
 #include <perspective/context_zero.h>
 #include <perspective/flat_traversal.h>
 #include <perspective/sym_table.h>
@@ -98,8 +98,10 @@ t_ctx0::get_column_count() const {
 
 std::vector<t_tscalar>
 t_ctx0::get_data(t_index start_row, t_index end_row, t_index start_col, t_index end_col) const {
-
-    auto ext = sanitize_get_data_extents(*this, start_row, end_row, start_col, end_col);
+    t_uindex ctx_nrows = get_row_count();
+    t_uindex ctx_ncols = get_column_count();
+    auto ext = sanitize_get_data_extents(
+        ctx_nrows, ctx_ncols, start_row, end_row, start_col, end_col);
 
     t_index nrows = ext.m_erow - ext.m_srow;
     t_index stride = ext.m_ecol - ext.m_scol;

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -13,19 +13,29 @@
 namespace perspective {
 
 template <typename CTX_T>
-t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx,
+t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
+    t_uindex end_row, t_uindex start_col, t_uindex end_col,
     std::shared_ptr<std::vector<t_tscalar>> slice,
     std::shared_ptr<std::vector<std::string>> column_names)
     : m_ctx(ctx)
+    , m_start_row(start_row)
+    , m_end_row(end_row)
+    , m_start_col(start_col)
+    , m_end_col(end_col)
     , m_slice(slice)
     , m_column_names(column_names) {}
 
 template <typename CTX_T>
-t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx,
+t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
+    t_uindex end_row, t_uindex start_col, t_uindex end_col,
     std::shared_ptr<std::vector<t_tscalar>> slice,
     std::shared_ptr<std::vector<std::string>> column_names,
     std::shared_ptr<std::vector<t_uindex>> column_indices)
     : m_ctx(ctx)
+    , m_start_row(start_row)
+    , m_end_row(end_row)
+    , m_start_col(start_col)
+    , m_end_col(end_col)
     , m_slice(slice)
     , m_column_names(column_names)
     , m_column_indices(column_indices) {}
@@ -45,7 +55,7 @@ t_data_slice<CTX_T>::~t_data_slice() {}
  */
 template <>
 t_tscalar
-t_data_slice<t_ctx0>::get(t_uindex ridx, t_uindex col) {
+t_data_slice<t_ctx0>::get(t_uindex ridx, t_uindex col) const {
     t_tscalar rv;
     rv.clear();
     return rv;
@@ -53,7 +63,7 @@ t_data_slice<t_ctx0>::get(t_uindex ridx, t_uindex col) {
 
 template <>
 t_tscalar
-t_data_slice<t_ctx1>::get(t_uindex ridx, t_uindex cidx) {
+t_data_slice<t_ctx1>::get(t_uindex ridx, t_uindex cidx) const {
     t_tscalar rv;
     rv.clear();
     return rv;
@@ -61,10 +71,22 @@ t_data_slice<t_ctx1>::get(t_uindex ridx, t_uindex cidx) {
 
 template <>
 t_tscalar
-t_data_slice<t_ctx2>::get(t_uindex ridx, t_uindex cidx) {
+t_data_slice<t_ctx2>::get(t_uindex ridx, t_uindex cidx) const {
     t_tscalar rv;
     rv.clear();
     return rv;
+}
+
+template <>
+std::vector<t_tscalar>
+t_data_slice<t_ctx0>::get_row_path(t_uindex idx) const {
+    return std::vector<t_tscalar>();
+}
+
+template <typename CTX_T>
+std::vector<t_tscalar>
+t_data_slice<CTX_T>::get_row_path(t_uindex idx) const {
+    return m_ctx->unity_get_row_path(idx);
 }
 
 // Getters
@@ -103,6 +125,16 @@ template <>
 bool
 t_data_slice<t_ctx0>::is_column_only() const {
     return false;
+}
+
+template <typename CTX_T>
+t_get_data_extents
+t_data_slice<CTX_T>::get_data_extents() const {
+    auto nrows = m_ctx->get_row_count();
+    auto ncols = m_ctx->get_column_count();
+    t_get_data_extents ext = sanitize_get_data_extents(
+        nrows, ncols, m_start_row, m_end_row, m_start_col, m_end_col);
+    return ext;
 }
 
 // Explicitly instantiate data slice for each context

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -1,0 +1,99 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#include <perspective/first.h>
+#include <perspective/data_slice.h>
+
+namespace perspective {
+
+template <typename CTX_T>
+t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx,
+    std::shared_ptr<std::vector<t_tscalar>> slice,
+    std::shared_ptr<std::vector<std::string>> column_names)
+    : m_ctx(ctx)
+    , m_slice(slice)
+    , m_column_names(column_names) {}
+
+template <typename CTX_T>
+t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx,
+    std::shared_ptr<std::vector<t_tscalar>> slice,
+    std::shared_ptr<std::vector<std::string>> column_names,
+    std::shared_ptr<std::vector<t_uindex>> column_indices)
+    : m_ctx(ctx)
+    , m_slice(slice)
+    , m_column_names(column_names)
+    , m_column_indices(column_indices) {}
+
+template <typename CTX_T>
+t_data_slice<CTX_T>::~t_data_slice() {}
+
+/**
+ * @brief Returns the t_tscalar at the declared indices in the data slice,
+ * or an invalid t_tscalar if the indices should be skipped.
+ *
+ * @param ridx row index into the slice
+ * @param cidx column index into the slice
+ *
+ * @return t_tscalar a valid scalar containing the underlying data, or a new
+ * t_tscalar initialized with an invalid flag.
+ */
+template <>
+t_tscalar
+t_data_slice<t_ctx0>::get(t_uindex ridx, t_uindex col) {
+    t_tscalar rv;
+    rv.clear();
+    return rv;
+}
+
+template <>
+t_tscalar
+t_data_slice<t_ctx1>::get(t_uindex ridx, t_uindex cidx) {
+    t_tscalar rv;
+    rv.clear();
+    return rv;
+}
+
+template <>
+t_tscalar
+t_data_slice<t_ctx2>::get(t_uindex ridx, t_uindex cidx) {
+    t_tscalar rv;
+    rv.clear();
+    return rv;
+}
+
+// Getters
+template <typename CTX_T>
+std::shared_ptr<CTX_T>
+t_data_slice<CTX_T>::get_context() const {
+    return m_ctx;
+}
+
+template <typename CTX_T>
+std::shared_ptr<std::vector<t_tscalar>>
+t_data_slice<CTX_T>::get_slice() const {
+    return m_slice;
+}
+
+template <typename CTX_T>
+std::shared_ptr<std::vector<std::string>>
+t_data_slice<CTX_T>::get_column_names() const {
+    return m_column_names;
+}
+
+template <typename CTX_T>
+std::shared_ptr<std::vector<t_uindex>>
+t_data_slice<CTX_T>::get_column_indices() const {
+    return m_column_indices;
+}
+
+// Explicitly instantiate data slice for each context
+template class t_data_slice<t_ctx0>;
+template class t_data_slice<t_ctx1>;
+template class t_data_slice<t_ctx2>;
+} // end namespace perspective

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -92,6 +92,19 @@ t_data_slice<CTX_T>::get_column_indices() const {
     return m_column_indices;
 }
 
+template <typename CTX_T>
+bool
+t_data_slice<CTX_T>::is_column_only() const {
+    auto config = m_ctx->get_config();
+    return config.is_column_only();
+}
+
+template <>
+bool
+t_data_slice<t_ctx0>::is_column_only() const {
+    return false;
+}
+
 // Explicitly instantiate data slice for each context
 template class t_data_slice<t_ctx0>;
 template class t_data_slice<t_ctx1>;

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1662,7 +1662,7 @@ namespace binding {
         auto schema = gnode->get_tblschema();
         t_config view_config = make_view_config<val>(schema, separator, date_parser, config);
 
-        bool column_only = view_config.get_column_only();
+        bool column_only = view_config.is_column_only();
         auto aggregates = view_config.get_aggregates();
         auto row_pivots = view_config.get_row_pivots();
         auto filter_op = view_config.get_combiner();
@@ -1690,7 +1690,7 @@ namespace binding {
         auto schema = gnode->get_tblschema();
         t_config view_config = make_view_config<val>(schema, separator, date_parser, config);
 
-        bool column_only = view_config.get_column_only();
+        bool column_only = view_config.is_column_only();
         auto column_names = view_config.get_column_names();
         auto row_pivots = view_config.get_row_pivots();
         auto column_pivots = view_config.get_column_pivots();
@@ -1717,7 +1717,8 @@ namespace binding {
         }
 
         auto ctx = make_context_two(schema, row_pivots, column_pivots, filter_op, filters,
-            aggregates, sorts, col_sorts, rpivot_depth, cpivot_depth, pool, gnode, name);
+            aggregates, sorts, col_sorts, rpivot_depth, cpivot_depth, column_only, pool, gnode,
+            name);
 
         auto view_ptr
             = std::make_shared<View<t_ctx2>>(pool, ctx, gnode, name, separator, view_config);
@@ -1765,7 +1766,7 @@ namespace binding {
         std::vector<t_fterm> filters, std::vector<t_aggspec> aggregates,
         std::vector<t_sortspec> sorts, std::int32_t pivot_depth, bool column_only, t_pool* pool,
         std::shared_ptr<t_gnode> gnode, std::string name) {
-        auto cfg = t_config(pivots, aggregates, combiner, filters);
+        auto cfg = t_config(pivots, aggregates, combiner, filters, column_only);
         auto ctx1 = std::make_shared<t_ctx1>(schema, cfg);
 
         ctx1->init();
@@ -1798,10 +1799,11 @@ namespace binding {
         std::vector<t_pivot> cpivots, t_filter_op combiner, std::vector<t_fterm> filters,
         std::vector<t_aggspec> aggregates, std::vector<t_sortspec> sorts,
         std::vector<t_sortspec> col_sorts, std::int32_t rpivot_depth, std::int32_t cpivot_depth,
-        t_pool* pool, std::shared_ptr<t_gnode> gnode, std::string name) {
+        bool column_only, t_pool* pool, std::shared_ptr<t_gnode> gnode, std::string name) {
         t_totals total = sorts.size() > 0 ? TOTALS_BEFORE : TOTALS_HIDDEN;
 
-        auto cfg = t_config(rpivots, cpivots, aggregates, total, combiner, filters);
+        auto cfg
+            = t_config(rpivots, cpivots, aggregates, total, combiner, filters, column_only);
         auto ctx2 = std::make_shared<t_ctx2>(schema, cfg);
 
         ctx2->init();

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1853,11 +1853,11 @@ namespace binding {
      * -------
      *
      */
-    template <typename T>
+    template <typename CTX_T>
     val
-    get_data(T ctx, std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
-        std::uint32_t end_col) {
-        auto slice = ctx->get_data(start_row, end_row, start_col, end_col);
+    get_data(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row, std::uint32_t end_row,
+        std::uint32_t start_col, std::uint32_t end_col) {
+        auto slice = view->get_data(start_row, end_row, start_col, end_col);
         val arr = val::array();
         for (auto idx = 0; idx < slice.size(); ++idx) {
             arr.set(idx, scalar_to_val(slice[idx]));
@@ -1867,9 +1867,10 @@ namespace binding {
 
     template <>
     val
-    get_data_two_skip_headers(std::shared_ptr<t_ctx2> ctx, std::uint32_t depth,
+    get_data_two_skip_headers(std::shared_ptr<View<t_ctx2>> view, std::uint32_t depth,
         std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
         std::uint32_t end_col) {
+        auto ctx = view->get_context();
         auto col_length = ctx->unity_get_column_count();
         std::vector<t_uindex> col_nums;
         col_nums.push_back(0);
@@ -1880,7 +1881,7 @@ namespace binding {
         }
         col_nums = std::vector<t_uindex>(col_nums.begin() + start_col,
             col_nums.begin() + std::min(end_col, (std::uint32_t)col_nums.size()));
-        auto slice = ctx->get_data(start_row, end_row, col_nums.front(), col_nums.back() + 1);
+        auto slice = view->get_data(start_row, end_row, col_nums.front(), col_nums.back() + 1);
         val arr = val::array();
         t_uindex i = 0;
         auto iter = slice.begin();
@@ -2151,9 +2152,9 @@ EMSCRIPTEN_BINDINGS(perspective) {
     function("clone_gnode_table", &clone_gnode_table<val>, allow_raw_pointers());
     function("scalar_vec_to_val", &scalar_vec_to_val);
     function("table_add_computed_column", &table_add_computed_column<val>);
-    function("get_data_zero", &get_data<std::shared_ptr<t_ctx0>>);
-    function("get_data_one", &get_data<std::shared_ptr<t_ctx1>>);
-    function("get_data_two", &get_data<std::shared_ptr<t_ctx2>>);
+    function("get_data_zero", &get_data<t_ctx0>);
+    function("get_data_one", &get_data<t_ctx1>);
+    function("get_data_two", &get_data<t_ctx2>);
     function("get_data_two_skip_headers", &get_data_two_skip_headers<val>);
     function("col_to_js_typed_array_zero", &col_to_js_typed_array<t_ctx0>);
     function("col_to_js_typed_array_one", &col_to_js_typed_array<t_ctx1>);

--- a/cpp/perspective/src/cpp/get_data_extents.cpp
+++ b/cpp/perspective/src/cpp/get_data_extents.cpp
@@ -6,29 +6,15 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
-
-#pragma once
-
 #include <perspective/first.h>
-#include <perspective/raw_types.h>
+#include <perspective/get_data_extents.h>
 
 namespace perspective {
-
-struct t_get_data_extents {
-    t_index m_srow;
-    t_index m_erow;
-    t_index m_scol;
-    t_index m_ecol;
-};
-
-template <typename CONTEXT_T>
 t_get_data_extents
-sanitize_get_data_extents(const CONTEXT_T& ctx, t_index start_row, t_index end_row,
+sanitize_get_data_extents(t_index nrows, t_index ncols, t_index start_row, t_index end_row,
     t_index start_col, t_index end_col) {
-    t_index ncols = ctx.get_column_count();
-
-    start_row = std::min(start_row, ctx.get_row_count());
-    end_row = std::min(end_row, ctx.get_row_count());
+    start_row = std::min(start_row, nrows);
+    end_row = std::min(end_row, nrows);
 
     start_row = std::max(t_index(0), start_row);
     end_row = std::max(t_index(0), end_row);

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -293,21 +293,23 @@ View<t_ctx0>::_column_names(bool skip, std::int32_t depth) const {
  * @return std::vector<t_tscalar>
  */
 template <typename CTX_T>
-t_data_slice
+t_data_slice<CTX_T>
 View<CTX_T>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
     std::uint32_t end_col) {
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
         m_ctx->get_data(start_row, end_row, start_col, end_col));
-    auto data_slice = t_data_slice{slice_ptr};
+    auto names_ptr = std::make_shared<std::vector<std::string>>(_column_names());
+    auto data_slice = t_data_slice<CTX_T>(m_ctx, slice_ptr, names_ptr);
     return data_slice;
 }
 
 template <>
-t_data_slice
+t_data_slice<t_ctx2>
 View<t_ctx2>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
     std::uint32_t end_col) {
     std::vector<t_tscalar> slice;
     std::vector<t_uindex> column_indices;
+    std::vector<std::string> column_names;
     bool is_sorted = m_sorts.size() > 0;
 
     if (is_sorted) {
@@ -320,18 +322,21 @@ View<t_ctx2>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint
             }
         }
 
+        column_names = _column_names(true, depth);
         column_indices = std::vector<t_uindex>(column_indices.begin() + start_col,
             column_indices.begin() + std::min(end_col, (std::uint32_t)column_indices.size()));
 
         slice = m_ctx->get_data(
             start_row, end_row, column_indices.front(), column_indices.back() + 1);
     } else {
+        column_names = _column_names();
         slice = m_ctx->get_data(start_row, end_row, start_col, end_col);
     }
 
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(slice);
-    auto col_indices_ptr = std::make_shared<std::vector<t_uindex>>(column_indices);
-    auto data_slice = t_data_slice{slice_ptr, col_indices_ptr};
+    auto names_ptr = std::make_shared<std::vector<std::string>>(column_names);
+    auto indices_ptr = std::make_shared<std::vector<t_uindex>>(column_indices);
+    auto data_slice = t_data_slice<t_ctx2>(m_ctx, slice_ptr, names_ptr, indices_ptr);
     return data_slice;
 }
 

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -299,7 +299,8 @@ View<CTX_T>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint3
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
         m_ctx->get_data(start_row, end_row, start_col, end_col));
     auto names_ptr = std::make_shared<std::vector<std::string>>(_column_names());
-    auto data_slice = t_data_slice<CTX_T>(m_ctx, slice_ptr, names_ptr);
+    auto data_slice = t_data_slice<CTX_T>(
+        m_ctx, start_row, end_row, start_col, end_col, slice_ptr, names_ptr);
     return data_slice;
 }
 
@@ -336,7 +337,8 @@ View<t_ctx2>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(slice);
     auto names_ptr = std::make_shared<std::vector<std::string>>(column_names);
     auto indices_ptr = std::make_shared<std::vector<t_uindex>>(column_indices);
-    auto data_slice = t_data_slice<t_ctx2>(m_ctx, slice_ptr, names_ptr, indices_ptr);
+    auto data_slice = t_data_slice<t_ctx2>(
+        m_ctx, start_row, end_row, start_col, end_col, slice_ptr, names_ptr, indices_ptr);
     return data_slice;
 }
 

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -287,6 +287,58 @@ View<t_ctx0>::_column_names(bool skip, std::int32_t depth) const {
     return names;
 }
 
+/**
+ * @brief Returns a slice of the underlying data of the view.
+ *
+ * @return std::vector<t_tscalar>
+ */
+template <typename CTX_T>
+std::vector<t_tscalar>
+View<CTX_T>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
+    std::uint32_t end_col) {
+    std::vector<t_tscalar> slice = m_ctx->get_data(start_row, end_row, start_col, end_col);
+    return slice;
+}
+
+/*template <>
+std::vector<t_tscalar>
+View<t_ctx2>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
+std::uint32_t end_col) { auto column_indices = std::vector<t_uindex>{0}; bool is_sorted =
+m_sorts.size() > 0;
+
+    if (is_sorted) {
+        auto depth = m_column_pivots.size();
+        auto col_length = m_ctx->unity_get_column_count();
+        for (t_uindex i = 0; i < col_length; ++i) {
+            if (m_ctx->unity_get_column_path(i + 1).size() == depth) {
+                column_indices.push_back(i + 1);
+            }
+        }
+    }
+
+    column_indices = std::vector<t_uindex>(column_indices.begin() + start_col,
+            column_indices.begin() + std::min(end_col, (std::uint32_t)column_indices.size()));
+
+    auto slice = m_ctx->get_data(start_row, end_row, column_indices.front(),
+column_indices.back() + 1);
+
+    t_uindex i = 0;
+    auto iter = slice.begin();
+    while (iter != slice.end()) {
+        t_uindex prev = column_indices.front();
+        for (auto idx = column_indices.begin(); idx != column_indices.end(); idx++, i++) {
+            t_uindex col_num = *idx;
+            iter += col_num - prev;
+            prev = col_num;
+            arr.set(i, scalar_to_val(*iter));
+        }
+        if (iter != slice.end())
+            iter++;
+    }
+
+    return slice;
+}*/
+
 // Getters
 template <typename CTX_T>
 std::shared_ptr<CTX_T>

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -34,7 +34,7 @@ View<CTX_T>::View(t_pool* pool, std::shared_ptr<CTX_T> ctx, std::shared_ptr<t_gn
     m_aggregates = m_config.get_aggregates();
     m_filters = m_config.get_fterms();
     m_sorts = m_config.get_sortspecs();
-    m_column_only = m_config.get_column_only();
+    m_column_only = m_config.is_column_only();
 }
 
 template <typename CTX_T>

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -365,7 +365,7 @@ namespace binding {
         std::vector<t_pivot> cpivots, t_filter_op combiner, std::vector<t_fterm> filters,
         std::vector<t_aggspec> aggregates, std::vector<t_sortspec> sorts,
         std::vector<t_sortspec> col_sorts, std::int32_t rpivot_depth, std::int32_t cpivot_depth,
-        t_pool* pool, std::shared_ptr<t_gnode> gnode, std::string name);
+        bool column_only, t_pool* pool, std::shared_ptr<t_gnode> gnode, std::string name);
 
     template <typename T>
     void sort(std::shared_ptr<t_ctx2> ctx2, T j_sortby);

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -384,12 +384,12 @@ namespace binding {
      * -------
      *
      */
-    template <typename T, typename U>
-    T get_data(U ctx, std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
-        std::uint32_t end_col);
+    template <typename CTX_T, typename T>
+    T get_data(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row,
+        std::uint32_t end_row, std::uint32_t start_col, std::uint32_t end_col);
 
     template <typename T>
-    T get_data_two_skip_headers(std::shared_ptr<t_ctx2> ctx, std::uint32_t depth,
+    T get_data_two_skip_headers(std::shared_ptr<View<t_ctx2>> view, std::uint32_t depth,
         std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
         std::uint32_t end_col);
 

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -73,7 +73,7 @@ public:
 
     t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_pivot>& col_pivots,
         const std::vector<t_aggspec>& aggregates, const t_totals totals, t_filter_op combiner,
-        const std::vector<t_fterm>& fterms);
+        const std::vector<t_fterm>& fterms, bool column_only);
 
     t_config(const std::vector<std::string>& row_pivots,
         const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates,
@@ -86,7 +86,7 @@ public:
     t_config(const std::vector<std::string>& row_pivots, const t_aggspec& agg);
 
     t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates,
-        t_filter_op combiner, const std::vector<t_fterm>& fterms);
+        t_filter_op combiner, const std::vector<t_fterm>& fterms, bool column_only);
 
     t_config(const std::vector<std::string>& row_pivots,
         const std::vector<t_aggspec>& aggregates, t_filter_op combiner,
@@ -122,7 +122,7 @@ public:
     std::vector<std::string> get_column_names() const;
     t_uindex get_num_rpivots() const;
     t_uindex get_num_cpivots() const;
-    bool get_column_only() const;
+    bool is_column_only() const;
 
     std::vector<t_pivot> get_pivots() const;
     const std::vector<t_pivot>& get_row_pivots() const;

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -13,6 +13,7 @@
 #include <perspective/base.h>
 #include <perspective/raw_types.h>
 #include <perspective/scalar.h>
+#include <perspective/get_data_extents.h>
 #include <perspective/context_zero.h>
 #include <perspective/context_one.h>
 #include <perspective/context_two.h>
@@ -34,10 +35,12 @@ namespace perspective {
 template <typename CTX_T>
 class PERSPECTIVE_EXPORT t_data_slice {
 public:
-    t_data_slice(std::shared_ptr<CTX_T> ctx, std::shared_ptr<std::vector<t_tscalar>> slice,
+    t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
+        t_uindex start_col, t_uindex end_col, std::shared_ptr<std::vector<t_tscalar>> slice,
         std::shared_ptr<std::vector<std::string>> column_names);
 
-    t_data_slice(std::shared_ptr<CTX_T> ctx, std::shared_ptr<std::vector<t_tscalar>> slice,
+    t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
+        t_uindex start_col, t_uindex end_col, std::shared_ptr<std::vector<t_tscalar>> slice,
         std::shared_ptr<std::vector<std::string>> column_names,
         std::shared_ptr<std::vector<t_uindex>> column_indices);
 
@@ -53,16 +56,23 @@ public:
      * @return t_tscalar a valid scalar containing the underlying data, or a new
      * t_tscalar initialized with an invalid flag.
      */
-    t_tscalar get(t_uindex ridx, t_uindex cidx);
+    t_tscalar get(t_uindex ridx, t_uindex cidx) const;
+
+    std::vector<t_tscalar> get_row_path(t_uindex idx) const;
 
     std::shared_ptr<CTX_T> get_context() const;
     std::shared_ptr<std::vector<t_tscalar>> get_slice() const;
     std::shared_ptr<std::vector<std::string>> get_column_names() const;
     std::shared_ptr<std::vector<t_uindex>> get_column_indices() const;
+    t_get_data_extents get_data_extents() const;
     bool is_column_only() const;
 
 private:
     std::shared_ptr<CTX_T> m_ctx;
+    t_uindex m_start_row;
+    t_uindex m_end_row;
+    t_uindex m_start_col;
+    t_uindex m_end_col;
     std::shared_ptr<std::vector<t_tscalar>> m_slice;
     std::shared_ptr<std::vector<std::string>> m_column_names;
     std::shared_ptr<std::vector<t_uindex>> m_column_indices;

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -59,6 +59,7 @@ public:
     std::shared_ptr<std::vector<t_tscalar>> get_slice() const;
     std::shared_ptr<std::vector<std::string>> get_column_names() const;
     std::shared_ptr<std::vector<t_uindex>> get_column_indices() const;
+    bool is_column_only() const;
 
 private:
     std::shared_ptr<CTX_T> m_ctx;

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2019, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#pragma once
+#include <perspective/first.h>
+#include <perspective/exports.h>
+#include <perspective/base.h>
+#include <perspective/raw_types.h>
+#include <perspective/scalar.h>
+#include <perspective/context_zero.h>
+#include <perspective/context_one.h>
+#include <perspective/context_two.h>
+
+namespace perspective {
+/**
+ * @class t_data_slice
+ *
+ * @brief t_data_slice contains a slice of the View's underlying data
+ * with the metadata required to correctly parse it.
+ *
+ * - m_view: a reference to the view from which we output data
+ * - m_slice: a reference to a vector of t_tscalar objects containing data
+ * - m_column_names: a reference to a vector of string column names from the view.
+ * - m_column_indices: an optional reference to a vector of t_uindex column indices, which
+ * we use for column-pivoted views.
+ *
+ */
+template <typename CTX_T>
+class PERSPECTIVE_EXPORT t_data_slice {
+public:
+    t_data_slice(std::shared_ptr<CTX_T> ctx, std::shared_ptr<std::vector<t_tscalar>> slice,
+        std::shared_ptr<std::vector<std::string>> column_names);
+
+    t_data_slice(std::shared_ptr<CTX_T> ctx, std::shared_ptr<std::vector<t_tscalar>> slice,
+        std::shared_ptr<std::vector<std::string>> column_names,
+        std::shared_ptr<std::vector<t_uindex>> column_indices);
+
+    ~t_data_slice();
+
+    /**
+     * @brief Returns the t_tscalar at the declared indices in the data slice,
+     * or an invalid t_tscalar if the indices should be skipped.
+     *
+     * @param ridx row index into the slice
+     * @param cidx column index into the slice
+     *
+     * @return t_tscalar a valid scalar containing the underlying data, or a new
+     * t_tscalar initialized with an invalid flag.
+     */
+    t_tscalar get(t_uindex ridx, t_uindex cidx);
+
+    std::shared_ptr<CTX_T> get_context() const;
+    std::shared_ptr<std::vector<t_tscalar>> get_slice() const;
+    std::shared_ptr<std::vector<std::string>> get_column_names() const;
+    std::shared_ptr<std::vector<t_uindex>> get_column_indices() const;
+
+private:
+    std::shared_ptr<CTX_T> m_ctx;
+    std::shared_ptr<std::vector<t_tscalar>> m_slice;
+    std::shared_ptr<std::vector<std::string>> m_column_names;
+    std::shared_ptr<std::vector<t_uindex>> m_column_indices;
+};
+} // end namespace perspective

--- a/cpp/perspective/src/include/perspective/get_data_extents.h
+++ b/cpp/perspective/src/include/perspective/get_data_extents.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+#pragma once
+
+#include <perspective/first.h>
+#include <perspective/raw_types.h>
+
+namespace perspective {
+
+struct t_get_data_extents {
+    t_index m_srow;
+    t_index m_erow;
+    t_index m_scol;
+    t_index m_ecol;
+};
+
+t_get_data_extents sanitize_get_data_extents(t_index nrows, t_index ncols, t_index start_row,
+    t_index end_row, t_index start_col, t_index end_col);
+} // namespace perspective

--- a/cpp/perspective/src/include/perspective/get_data_extents.h
+++ b/cpp/perspective/src/include/perspective/get_data_extents.h
@@ -11,6 +11,7 @@
 
 #include <perspective/first.h>
 #include <perspective/raw_types.h>
+#include <algorithm>
 
 namespace perspective {
 

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -23,6 +23,15 @@
 #include <map>
 
 namespace perspective {
+/**
+ * @brief t_data_slice contains a slice of the View's underlying data
+ * with the metadata required to correctly parse it.
+ *
+ */
+struct t_data_slice {
+    std::shared_ptr<std::vector<t_tscalar>> slice;
+    std::shared_ptr<std::vector<t_uindex>> column_indices;
+};
 
 template <typename CTX_T>
 class PERSPECTIVE_EXPORT View {
@@ -46,7 +55,7 @@ public:
     void set_depth(std::int32_t depth, std::int32_t row_pivot_length);
 
     // Data serialization
-    std::vector<t_tscalar> get_data(std::uint32_t start_row, std::uint32_t end_row,
+    t_data_slice get_data(std::uint32_t start_row, std::uint32_t end_row,
         std::uint32_t start_col, std::uint32_t end_col);
 
     // Getters

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -18,20 +18,12 @@
 #include <perspective/context_zero.h>
 #include <perspective/context_one.h>
 #include <perspective/context_two.h>
+#include <perspective/data_slice.h>
 #include <cstddef>
 #include <memory>
 #include <map>
 
 namespace perspective {
-/**
- * @brief t_data_slice contains a slice of the View's underlying data
- * with the metadata required to correctly parse it.
- *
- */
-struct t_data_slice {
-    std::shared_ptr<std::vector<t_tscalar>> slice;
-    std::shared_ptr<std::vector<t_uindex>> column_indices;
-};
 
 template <typename CTX_T>
 class PERSPECTIVE_EXPORT View {
@@ -55,7 +47,7 @@ public:
     void set_depth(std::int32_t depth, std::int32_t row_pivot_length);
 
     // Data serialization
-    t_data_slice get_data(std::uint32_t start_row, std::uint32_t end_row,
+    t_data_slice<CTX_T> get_data(std::uint32_t start_row, std::uint32_t end_row,
         std::uint32_t start_col, std::uint32_t end_col);
 
     // Getters

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -45,6 +45,10 @@ public:
     t_index collapse(std::int32_t idx);
     void set_depth(std::int32_t depth, std::int32_t row_pivot_length);
 
+    // Data serialization
+    std::vector<t_tscalar> get_data(std::uint32_t start_row, std::uint32_t end_row,
+        std::uint32_t start_col, std::uint32_t end_col);
+
     // Getters
     std::shared_ptr<CTX_T> get_context() const;
     std::vector<std::string> get_row_pivots() const;

--- a/packages/perspective/bench/js/bench.js
+++ b/packages/perspective/bench/js/bench.js
@@ -51,7 +51,6 @@ function transpose(json) {
 async function run() {
     // Allow users to set a limit on version lookbacks
     let psp_urls = URLS;
-    console.log(`limit: ${LIMIT}`);
     if (LIMIT !== -1) {
         let limit_num = Number(args[LIMIT + 1]);
         if (!isNaN(limit_num) && limit_num > 0 && limit_num <= psp_urls.length) {

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -326,6 +326,19 @@ export default function(Module) {
             depth = this.config.column_pivot.length;
         }
 
+        /*
+        let num_rows = this.num_rows();
+        let num_cols = this.num_cols();
+        let column_names = extract_vector(data_slice.get_column_names());
+        for (let ridx = 0; ridx < num_rows; ridx++) {
+            row = {}; // or array for col, etc;
+            for (let cidx = 0; cidx < num_cols; cidx++) {
+                row[column_names[cidx]] = data_slice.get(ridx, cidx);
+            }
+            data.push(row);
+        }
+        */
+
         let col_names = [[]].concat(this._column_names(skip, depth));
         let row;
         let ridx = -1;

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -309,13 +309,13 @@ export default function(Module) {
         }
 
         if (this.sides() === 0) {
-            slice = __MODULE__.get_data_zero(this.ctx, start_row, end_row, start_col, end_col);
+            slice = __MODULE__.get_data_zero(this._View, start_row, end_row, start_col, end_col);
         } else if (this.sides() === 1) {
-            slice = __MODULE__.get_data_one(this.ctx, start_row, end_row, start_col, end_col);
+            slice = __MODULE__.get_data_one(this._View, start_row, end_row, start_col, end_col);
         } else if (!sorted) {
-            slice = __MODULE__.get_data_two(this.ctx, start_row, end_row, start_col, end_col);
+            slice = __MODULE__.get_data_two(this._View, start_row, end_row, start_col, end_col);
         } else {
-            slice = __MODULE__.get_data_two_skip_headers(this.ctx, this.config.column_pivot.length, start_row, end_row, start_col, end_col);
+            slice = __MODULE__.get_data_two_skip_headers(this._View, this.config.column_pivot.length, start_row, end_row, start_col, end_col);
         }
 
         let data = formatter.initDataValue();

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -312,10 +312,8 @@ export default function(Module) {
             slice = __MODULE__.get_data_zero(this._View, start_row, end_row, start_col, end_col);
         } else if (this.sides() === 1) {
             slice = __MODULE__.get_data_one(this._View, start_row, end_row, start_col, end_col);
-        } else if (!sorted) {
-            slice = __MODULE__.get_data_two(this._View, start_row, end_row, start_col, end_col);
         } else {
-            slice = __MODULE__.get_data_two_skip_headers(this._View, this.config.column_pivot.length, start_row, end_row, start_col, end_col);
+            slice = __MODULE__.get_data_two(this._View, start_row, end_row, start_col, end_col);
         }
 
         let data = formatter.initDataValue();

--- a/python/perspective/src/python.cpp
+++ b/python/perspective/src/python.cpp
@@ -504,15 +504,15 @@ py::object get_column_data(std::shared_ptr<t_table> table, std::string colname) 
  * -------
  *
  */
-template <typename T>
-py::object get_data(T ctx, std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
+template <typename CTX_T>
+py::object get_data(std::shared_ptr<View<CTX_T> > view, std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
     std::uint32_t end_col) {
     py::list arr;
     return arr;
 }
 
 template <>
-py::object get_data_two_skip_headers(std::shared_ptr<t_ctx2> ctx, std::uint32_t depth,
+py::object get_data_two_skip_headers(std::shared_ptr<View<t_ctx2> > view, std::uint32_t depth,
     std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
     std::uint32_t end_col) {
     py::list arr;


### PR DESCRIPTION
This PR begins to abstract the process of getting data out of perspective for use in visualizations/serialization. Right now, we create an intermediate array inside `emscripten.cpp` that contains the data extracted from the context. The end goal of the PR is to eliminate that intermediate structure—and the logic surrounding it—so as to make the data output API portable and trivial to implement in binding languages.

`t_data_slice` is a class that contains the underlying slice of data and associated metadata, which allows us to eventually remove the intermediate logic of `get_data` in `emscripten.cpp`. 

_Changes_
- Adds `t_data_slice` class
- Adds `is_column_only` to context construction
- Moves `get_column_extent` to independent class

Making the PR so we can discuss and get these changes into mainline before the branch gets too big; I've tried to benchmark these changes but the script seems to be broken on my machine and isn't benching properly. 