### PR TITLE
Implement t_data_slice API for data extraction from 0 & 1-sided views

### DIFF
--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -206,9 +206,8 @@ t_config::t_config(const std::vector<std::string>& row_pivots, const t_aggspec& 
 
 t_config::t_config(const std::vector<t_pivot>& row_pivots,
     const std::vector<t_aggspec>& aggregates, t_filter_op combiner,
-    const std::vector<t_fterm>& fterms, bool column_only)
+    const std::vector<t_fterm>& fterms)
     : m_row_pivots(row_pivots)
-    , m_column_only(column_only)
     , m_aggregates(aggregates)
     , m_totals(TOTALS_BEFORE)
     , m_combiner(combiner)

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -49,40 +49,19 @@ t_data_slice<CTX_T>::~t_data_slice() {}
  * @brief Returns the t_tscalar at the declared indices in the data slice,
  * or an invalid t_tscalar if the indices should be skipped.
  *
+ * // TODO: re-specialize for t_ctx2 in order to implement skip logic
+ *
  * @param ridx row index into the slice
  * @param cidx column index into the slice
  *
  * @return t_tscalar a valid scalar containing the underlying data, or a new
  * t_tscalar initialized with an invalid flag.
  */
-template <>
+template <typename CTX_T>
 t_tscalar
-t_data_slice<t_ctx0>::get(t_index ridx, t_index cidx) const {
+t_data_slice<CTX_T>::get(t_index ridx, t_index cidx) const {
     t_index idx = get_slice_idx(ridx, cidx);
-    t_tscalar rv = m_slice->at(idx);
-    return rv;
-}
-
-template <>
-t_tscalar
-t_data_slice<t_ctx1>::get(t_index ridx, t_index cidx) const {
-    t_index idx = get_slice_idx(ridx, cidx);
-    t_tscalar rv = m_slice->at(idx);
-    return rv;
-}
-
-template <>
-t_tscalar
-t_data_slice<t_ctx2>::get(t_index ridx, t_index cidx) const {
-    t_index idx = get_slice_idx(ridx, cidx);
-    t_tscalar rv;
-    if (m_column_indices.size() > 0) {
-        // Skip data for header rows
-        // rv.clear()
-        rv = m_slice->at(idx);
-    } else {
-        rv = m_slice->at(idx);
-    }
+    t_tscalar rv = m_slice->operator[](idx);
     return rv;
 }
 

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -122,14 +122,14 @@ t_data_slice<CTX_T>::get_column_indices() const {
 template <typename CTX_T>
 bool
 t_data_slice<CTX_T>::is_column_only() const {
-    auto config = m_ctx->get_config();
-    return config.is_column_only();
+    return false;
 }
 
 template <>
 bool
-t_data_slice<t_ctx0>::is_column_only() const {
-    return false;
+t_data_slice<t_ctx2>::is_column_only() const {
+    auto config = m_ctx->get_config();
+    return config.is_column_only();
 }
 
 template <typename CTX_T>

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -13,8 +13,8 @@
 namespace perspective {
 
 template <typename CTX_T>
-t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_index start_row,
-    t_index end_row, t_index start_col, t_index end_col,
+t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
+    t_uindex end_row, t_uindex start_col, t_uindex end_col,
     const std::shared_ptr<std::vector<t_tscalar>>& slice, std::vector<std::string> column_names)
     : m_ctx(ctx)
     , m_start_row(start_row)
@@ -27,10 +27,10 @@ t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_index start_row,
 }
 
 template <typename CTX_T>
-t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_index start_row,
-    t_index end_row, t_index start_col, t_index end_col,
+t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
+    t_uindex end_row, t_uindex start_col, t_uindex end_col,
     const std::shared_ptr<std::vector<t_tscalar>>& slice, std::vector<std::string> column_names,
-    std::vector<t_index> column_indices)
+    std::vector<t_uindex> column_indices)
     : m_ctx(ctx)
     , m_start_row(start_row)
     , m_end_row(end_row)
@@ -49,8 +49,6 @@ t_data_slice<CTX_T>::~t_data_slice() {}
  * @brief Returns the t_tscalar at the declared indices in the data slice,
  * or an invalid t_tscalar if the indices should be skipped.
  *
- * // TODO: re-specialize for t_ctx2 in order to implement skip logic
- *
  * @param ridx row index into the slice
  * @param cidx column index into the slice
  *
@@ -59,22 +57,40 @@ t_data_slice<CTX_T>::~t_data_slice() {}
  */
 template <typename CTX_T>
 t_tscalar
-t_data_slice<CTX_T>::get(t_index ridx, t_index cidx) const {
-    t_index idx = get_slice_idx(ridx, cidx);
+t_data_slice<CTX_T>::get(t_uindex ridx, t_uindex cidx) const {
+    t_uindex idx = get_slice_idx(ridx, cidx);
+    t_tscalar rv;
+    if (idx >= m_slice->size()) {
+        rv.clear();
+    } else {
+        rv = m_slice->at(idx);
+    }
+    return rv;
+}
+
+template <>
+t_tscalar
+t_data_slice<t_ctx2>::get(t_uindex ridx, t_uindex cidx) const {
+    t_uindex idx = get_slice_idx(ridx, cidx);
     t_tscalar rv = m_slice->operator[](idx);
+    /* if (m_column_indices.size() > 0) {
+        t_uindex idx_skip_headers;
+    } else {
+
+    } */
     return rv;
 }
 
 template <typename CTX_T>
 std::vector<t_tscalar>
-t_data_slice<CTX_T>::get_row_path(t_index idx) const {
+t_data_slice<CTX_T>::get_row_path(t_uindex idx) const {
     return m_ctx->unity_get_row_path(idx);
 }
 
 template <typename CTX_T>
-t_index
-t_data_slice<CTX_T>::get_slice_idx(t_index ridx, t_index cidx) const {
-    t_index idx = (ridx - m_start_row) * m_stride + (cidx - m_start_col);
+t_uindex
+t_data_slice<CTX_T>::get_slice_idx(t_uindex ridx, t_uindex cidx) const {
+    t_uindex idx = (ridx - m_start_row) * m_stride + (cidx - m_start_col);
     return idx;
 }
 
@@ -98,7 +114,7 @@ t_data_slice<CTX_T>::get_column_names() const {
 }
 
 template <typename CTX_T>
-const std::vector<t_index>&
+const std::vector<t_uindex>&
 t_data_slice<CTX_T>::get_column_indices() const {
     return m_column_indices;
 }
@@ -117,7 +133,7 @@ t_data_slice<t_ctx0>::is_column_only() const {
 }
 
 template <typename CTX_T>
-t_index
+t_uindex
 t_data_slice<CTX_T>::get_stride() const {
     return m_stride;
 }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -2109,16 +2109,19 @@ EMSCRIPTEN_BINDINGS(perspective) {
     class_<t_data_slice<t_ctx0>>("t_data_slice_ctx0")
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx0>>>("shared_ptr<t_data_slice<t_ctx0>>>")
         .function<const std::vector<std::string>&>(
-            "get_column_names", &t_data_slice<t_ctx0>::get_column_names, allow_raw_pointers());
+            "get_column_names", &t_data_slice<t_ctx0>::get_column_names);
+            
     class_<t_data_slice<t_ctx1>>("t_data_slice_ctx1")
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx1>>>("shared_ptr<t_data_slice<t_ctx1>>>")
         .function<const std::vector<std::string>&>(
-            "get_column_names", &t_data_slice<t_ctx1>::get_column_names, allow_raw_pointers())
+            "get_column_names", &t_data_slice<t_ctx1>::get_column_names)
         .function<std::vector<t_tscalar>>("get_row_path", &t_data_slice<t_ctx1>::get_row_path);
+
     class_<t_data_slice<t_ctx2>>("t_data_slice_ctx2")
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx2>>>("shared_ptr<t_data_slice<t_ctx2>>>")
         .function<const std::vector<std::string>&>(
-            "get_column_names", &t_data_slice<t_ctx2>::get_column_names, allow_raw_pointers());
+            "get_column_names", &t_data_slice<t_ctx2>::get_column_names);
+
     /******************************************************************************
      *
      * t_ctx0

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1663,7 +1663,6 @@ namespace binding {
         auto schema = gnode->get_tblschema();
         t_config view_config = make_view_config<val>(schema, separator, date_parser, config);
 
-        bool column_only = view_config.is_column_only();
         auto aggregates = view_config.get_aggregates();
         auto row_pivots = view_config.get_row_pivots();
         auto filter_op = view_config.get_combiner();
@@ -1676,7 +1675,7 @@ namespace binding {
         }
 
         auto ctx = make_context_one(schema, row_pivots, filter_op, filters, aggregates, sorts,
-            pivot_depth, column_only, pool, gnode, name);
+            pivot_depth, pool, gnode, name);
 
         auto view_ptr
             = std::make_shared<View<t_ctx1>>(pool, ctx, gnode, name, separator, view_config);
@@ -1765,9 +1764,9 @@ namespace binding {
     std::shared_ptr<t_ctx1>
     make_context_one(t_schema schema, std::vector<t_pivot> pivots, t_filter_op combiner,
         std::vector<t_fterm> filters, std::vector<t_aggspec> aggregates,
-        std::vector<t_sortspec> sorts, std::int32_t pivot_depth, bool column_only, t_pool* pool,
+        std::vector<t_sortspec> sorts, std::int32_t pivot_depth, t_pool* pool,
         std::shared_ptr<t_gnode> gnode, std::string name) {
-        auto cfg = t_config(pivots, aggregates, combiner, filters, column_only);
+        auto cfg = t_config(pivots, aggregates, combiner, filters);
         auto ctx1 = std::make_shared<t_ctx1>(schema, cfg);
 
         ctx1->init();
@@ -2110,7 +2109,7 @@ EMSCRIPTEN_BINDINGS(perspective) {
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx0>>>("shared_ptr<t_data_slice<t_ctx0>>>")
         .function<const std::vector<std::string>&>(
             "get_column_names", &t_data_slice<t_ctx0>::get_column_names);
-            
+
     class_<t_data_slice<t_ctx1>>("t_data_slice_ctx1")
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx1>>>("shared_ptr<t_data_slice<t_ctx1>>>")
         .function<const std::vector<std::string>&>(

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1961,7 +1961,7 @@ namespace binding {
     template <typename CTX_T>
     val
     get_from_data_slice(
-        std::shared_ptr<t_data_slice<CTX_T>> data_slice, t_index ridx, t_index cidx) {
+        std::shared_ptr<t_data_slice<CTX_T>> data_slice, t_uindex ridx, t_uindex cidx) {
         auto d = data_slice->get(ridx, cidx);
         return scalar_to_val(d);
     }
@@ -2024,7 +2024,6 @@ EMSCRIPTEN_BINDINGS(perspective) {
         .function("get_aggregates", &View<t_ctx0>::get_aggregates)
         .function("get_filters", &View<t_ctx0>::get_filters)
         .function("get_sorts", &View<t_ctx0>::get_sorts)
-        .function("get_row_path", &View<t_ctx0>::get_row_path)
         .function("get_step_delta", &View<t_ctx0>::get_step_delta)
         .function("is_column_only", &View<t_ctx0>::is_column_only);
 
@@ -2047,7 +2046,6 @@ EMSCRIPTEN_BINDINGS(perspective) {
         .function("get_aggregates", &View<t_ctx1>::get_aggregates)
         .function("get_filters", &View<t_ctx1>::get_filters)
         .function("get_sorts", &View<t_ctx1>::get_sorts)
-        .function("get_row_path", &View<t_ctx1>::get_row_path)
         .function("get_step_delta", &View<t_ctx1>::get_step_delta)
         .function("is_column_only", &View<t_ctx1>::is_column_only);
 
@@ -2115,7 +2113,8 @@ EMSCRIPTEN_BINDINGS(perspective) {
     class_<t_data_slice<t_ctx1>>("t_data_slice_ctx1")
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx1>>>("shared_ptr<t_data_slice<t_ctx1>>>")
         .function<const std::vector<std::string>&>(
-            "get_column_names", &t_data_slice<t_ctx1>::get_column_names, allow_raw_pointers());
+            "get_column_names", &t_data_slice<t_ctx1>::get_column_names, allow_raw_pointers())
+        .function<std::vector<t_tscalar>>("get_row_path", &t_data_slice<t_ctx1>::get_row_path);
     class_<t_data_slice<t_ctx2>>("t_data_slice_ctx2")
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx2>>>("shared_ptr<t_data_slice<t_ctx2>>>")
         .function<const std::vector<std::string>&>(

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1943,7 +1943,6 @@ namespace binding {
     std::shared_ptr<t_data_slice<CTX_T>>
     get_data_slice(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row,
         std::uint32_t end_row, std::uint32_t start_col, std::uint32_t end_col) {
-        val arr = val::array();
         auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
         return data_slice;
     }
@@ -1963,8 +1962,8 @@ namespace binding {
     val
     get_from_data_slice(
         std::shared_ptr<t_data_slice<CTX_T>> data_slice, t_index ridx, t_index cidx) {
-        auto sc = data_slice->get(ridx, cidx);
-        return scalar_to_val(sc);
+        auto d = data_slice->get(ridx, cidx);
+        return scalar_to_val(d);
     }
 
 } // end namespace binding
@@ -2247,4 +2246,8 @@ EMSCRIPTEN_BINDINGS(perspective) {
     function("make_view_two", &make_view_two<val>, allow_raw_pointers());
     function("get_data_slice_zero", &get_data_slice<t_ctx0>, allow_raw_pointers());
     function("get_from_data_slice_zero", &get_from_data_slice<t_ctx0>, allow_raw_pointers());
+    function("get_data_slice_one", &get_data_slice<t_ctx1>, allow_raw_pointers());
+    function("get_from_data_slice_one", &get_from_data_slice<t_ctx1>, allow_raw_pointers());
+    function("get_data_slice_two", &get_data_slice<t_ctx2>, allow_raw_pointers());
+    function("get_from_data_slice_two", &get_from_data_slice<t_ctx2>, allow_raw_pointers());
 }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1876,7 +1876,7 @@ namespace binding {
         std::uint32_t start_col, std::uint32_t end_col) {
         val arr = val::array();
         auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
-        auto slice = data_slice.get_slice();
+        auto slice = data_slice->get_slice();
         for (auto idx = 0; idx < slice->size(); ++idx) {
             arr.set(idx, scalar_to_val(slice->at(idx)));
         }
@@ -1901,15 +1901,15 @@ namespace binding {
         std::uint32_t start_col, std::uint32_t end_col) {
         val arr = val::array();
         auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
-        auto slice = data_slice.get_slice();
-        auto column_indices = data_slice.get_column_indices();
+        auto slice = data_slice->get_slice();
+        auto column_indices = data_slice->get_column_indices();
 
-        if (column_indices->size() > 0) {
+        if (column_indices.size() > 0) {
             t_uindex i = 0;
             auto iter = slice->begin();
             while (iter != slice->end()) {
-                t_uindex prev = column_indices->front();
-                for (auto idx = column_indices->begin(); idx != column_indices->end();
+                t_uindex prev = column_indices.front();
+                for (auto idx = column_indices.begin(); idx != column_indices.end();
                      idx++, i++) {
                     t_uindex col_num = *idx;
                     iter += col_num - prev;
@@ -1926,6 +1926,45 @@ namespace binding {
         }
 
         return arr;
+    }
+
+    /**
+     * @brief Get the t_data_slice object, which contains an underlying slice of data and
+     * metadata required to interact with it.
+     *
+     * @param view
+     * @param start_row
+     * @param end_row
+     * @param start_col
+     * @param end_col
+     * @return val
+     */
+    template <typename CTX_T>
+    std::shared_ptr<t_data_slice<CTX_T>>
+    get_data_slice(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row,
+        std::uint32_t end_row, std::uint32_t start_col, std::uint32_t end_col) {
+        val arr = val::array();
+        auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
+        return data_slice;
+    }
+
+    /**
+     * @brief Retrieve a single value from the data slice and serialize it to an output
+     * type that interfaces with the binding language.
+     *
+     * @param view
+     * @param start_row
+     * @param end_row
+     * @param start_col
+     * @param end_col
+     * @return val
+     */
+    template <typename CTX_T>
+    val
+    get_from_data_slice(
+        std::shared_ptr<t_data_slice<CTX_T>> data_slice, t_index ridx, t_index cidx) {
+        auto sc = data_slice->get(ridx, cidx);
+        return scalar_to_val(sc);
     }
 
 } // end namespace binding
@@ -2070,9 +2109,18 @@ EMSCRIPTEN_BINDINGS(perspective) {
      *
      * t_data_slice
      */
-    class_<t_data_slice<t_ctx0>>("t_data_slice_ctx0");
-    class_<t_data_slice<t_ctx1>>("t_data_slice_ctx1");
-    class_<t_data_slice<t_ctx2>>("t_data_slice_ctx2");
+    class_<t_data_slice<t_ctx0>>("t_data_slice_ctx0")
+        .smart_ptr<std::shared_ptr<t_data_slice<t_ctx0>>>("shared_ptr<t_data_slice<t_ctx0>>>")
+        .function<const std::vector<std::string>&>(
+            "get_column_names", &t_data_slice<t_ctx0>::get_column_names, allow_raw_pointers());
+    class_<t_data_slice<t_ctx1>>("t_data_slice_ctx1")
+        .smart_ptr<std::shared_ptr<t_data_slice<t_ctx1>>>("shared_ptr<t_data_slice<t_ctx1>>>")
+        .function<const std::vector<std::string>&>(
+            "get_column_names", &t_data_slice<t_ctx1>::get_column_names, allow_raw_pointers());
+    class_<t_data_slice<t_ctx2>>("t_data_slice_ctx2")
+        .smart_ptr<std::shared_ptr<t_data_slice<t_ctx2>>>("shared_ptr<t_data_slice<t_ctx2>>>")
+        .function<const std::vector<std::string>&>(
+            "get_column_names", &t_data_slice<t_ctx2>::get_column_names, allow_raw_pointers());
     /******************************************************************************
      *
      * t_ctx0
@@ -2197,4 +2245,6 @@ EMSCRIPTEN_BINDINGS(perspective) {
     function("make_view_zero", &make_view_zero<val>, allow_raw_pointers());
     function("make_view_one", &make_view_one<val>, allow_raw_pointers());
     function("make_view_two", &make_view_two<val>, allow_raw_pointers());
+    function("get_data_slice_zero", &get_data_slice<t_ctx0>, allow_raw_pointers());
+    function("get_from_data_slice_zero", &get_from_data_slice<t_ctx0>, allow_raw_pointers());
 }

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -294,7 +294,8 @@ View<t_ctx0>::_column_names(bool skip, std::int32_t depth) const {
  */
 template <typename CTX_T>
 std::shared_ptr<t_data_slice<CTX_T>>
-View<CTX_T>::get_data(t_index start_row, t_index end_row, t_index start_col, t_index end_col) {
+View<CTX_T>::get_data(
+    t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col) {
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
         m_ctx->get_data(start_row, end_row, start_col, end_col));
     auto col_names = _column_names();
@@ -305,9 +306,10 @@ View<CTX_T>::get_data(t_index start_row, t_index end_row, t_index start_col, t_i
 
 template <>
 std::shared_ptr<t_data_slice<t_ctx2>>
-View<t_ctx2>::get_data(t_index start_row, t_index end_row, t_index start_col, t_index end_col) {
+View<t_ctx2>::get_data(
+    t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col) {
     std::vector<t_tscalar> slice;
-    std::vector<t_index> column_indices;
+    std::vector<t_uindex> column_indices;
     std::vector<std::string> column_names;
     bool is_sorted = m_sorts.size() > 0;
 
@@ -322,8 +324,8 @@ View<t_ctx2>::get_data(t_index start_row, t_index end_row, t_index start_col, t_
         }
 
         column_names = _column_names(true, depth);
-        column_indices = std::vector<t_index>(column_indices.begin() + start_col,
-            column_indices.begin() + std::min(end_col, (t_index)column_indices.size()));
+        column_indices = std::vector<t_uindex>(column_indices.begin() + start_col,
+            column_indices.begin() + std::min(end_col, (t_uindex)column_indices.size()));
 
         slice = m_ctx->get_data(
             start_row, end_row, column_indices.front(), column_indices.back() + 1);

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -34,7 +34,6 @@ View<CTX_T>::View(t_pool* pool, std::shared_ptr<CTX_T> ctx, std::shared_ptr<t_gn
     m_aggregates = m_config.get_aggregates();
     m_filters = m_config.get_fterms();
     m_sorts = m_config.get_sortspecs();
-    m_column_only = m_config.is_column_only();
 }
 
 template <typename CTX_T>
@@ -411,7 +410,7 @@ View<CTX_T>::get_step_delta(t_index bidx, t_index eidx) const {
 template <typename CTX_T>
 bool
 View<CTX_T>::is_column_only() const {
-    return m_column_only;
+    return m_config.is_column_only();
 }
 
 /******************************************************************************

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -293,23 +293,21 @@ View<t_ctx0>::_column_names(bool skip, std::int32_t depth) const {
  * @return std::vector<t_tscalar>
  */
 template <typename CTX_T>
-t_data_slice<CTX_T>
-View<CTX_T>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
-    std::uint32_t end_col) {
+std::shared_ptr<t_data_slice<CTX_T>>
+View<CTX_T>::get_data(t_index start_row, t_index end_row, t_index start_col, t_index end_col) {
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
         m_ctx->get_data(start_row, end_row, start_col, end_col));
-    auto names_ptr = std::make_shared<std::vector<std::string>>(_column_names());
-    auto data_slice = t_data_slice<CTX_T>(
-        m_ctx, start_row, end_row, start_col, end_col, slice_ptr, names_ptr);
-    return data_slice;
+    auto col_names = _column_names();
+    auto data_slice_ptr = std::make_shared<t_data_slice<CTX_T>>(
+        m_ctx, start_row, end_row, start_col, end_col, slice_ptr, col_names);
+    return data_slice_ptr;
 }
 
 template <>
-t_data_slice<t_ctx2>
-View<t_ctx2>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
-    std::uint32_t end_col) {
+std::shared_ptr<t_data_slice<t_ctx2>>
+View<t_ctx2>::get_data(t_index start_row, t_index end_row, t_index start_col, t_index end_col) {
     std::vector<t_tscalar> slice;
-    std::vector<t_uindex> column_indices;
+    std::vector<t_index> column_indices;
     std::vector<std::string> column_names;
     bool is_sorted = m_sorts.size() > 0;
 
@@ -324,8 +322,8 @@ View<t_ctx2>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint
         }
 
         column_names = _column_names(true, depth);
-        column_indices = std::vector<t_uindex>(column_indices.begin() + start_col,
-            column_indices.begin() + std::min(end_col, (std::uint32_t)column_indices.size()));
+        column_indices = std::vector<t_index>(column_indices.begin() + start_col,
+            column_indices.begin() + std::min(end_col, (t_index)column_indices.size()));
 
         slice = m_ctx->get_data(
             start_row, end_row, column_indices.front(), column_indices.back() + 1);
@@ -335,11 +333,9 @@ View<t_ctx2>::get_data(std::uint32_t start_row, std::uint32_t end_row, std::uint
     }
 
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(slice);
-    auto names_ptr = std::make_shared<std::vector<std::string>>(column_names);
-    auto indices_ptr = std::make_shared<std::vector<t_uindex>>(column_indices);
-    auto data_slice = t_data_slice<t_ctx2>(
-        m_ctx, start_row, end_row, start_col, end_col, slice_ptr, names_ptr, indices_ptr);
-    return data_slice;
+    auto data_slice_ptr = std::make_shared<t_data_slice<t_ctx2>>(
+        m_ctx, start_row, end_row, start_col, end_col, slice_ptr, column_names, column_indices);
+    return data_slice_ptr;
 }
 
 // Getters

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -292,14 +292,27 @@ View<t_ctx0>::_column_names(bool skip, std::int32_t depth) const {
  *
  * @return std::vector<t_tscalar>
  */
-template <typename CTX_T>
-std::shared_ptr<t_data_slice<CTX_T>>
-View<CTX_T>::get_data(
+template <>
+std::shared_ptr<t_data_slice<t_ctx0>>
+View<t_ctx0>::get_data(
     t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col) {
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
         m_ctx->get_data(start_row, end_row, start_col, end_col));
     auto col_names = _column_names();
-    auto data_slice_ptr = std::make_shared<t_data_slice<CTX_T>>(
+    auto data_slice_ptr = std::make_shared<t_data_slice<t_ctx0>>(
+        m_ctx, start_row, end_row, start_col, end_col, slice_ptr, col_names);
+    return data_slice_ptr;
+}
+
+template <>
+std::shared_ptr<t_data_slice<t_ctx1>>
+View<t_ctx1>::get_data(
+    t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col) {
+    auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
+        m_ctx->get_data(start_row, end_row, start_col, end_col));
+    auto col_names = _column_names();
+    col_names.insert(col_names.begin(), "__ROW_PATH__");
+    auto data_slice_ptr = std::make_shared<t_data_slice<t_ctx1>>(
         m_ctx, start_row, end_row, start_col, end_col, slice_ptr, col_names);
     return data_slice_ptr;
 }

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -347,7 +347,7 @@ namespace binding {
      */
     std::shared_ptr<t_ctx1> make_context_one(t_schema schema, std::vector<t_pivot> pivots,
         t_filter_op combiner, std::vector<t_fterm> filters, std::vector<t_aggspec> aggregates,
-        std::vector<t_sortspec> sorts, std::int32_t pivot_depth, bool column_only, t_pool* pool,
+        std::vector<t_sortspec> sorts, std::int32_t pivot_depth, t_pool* pool,
         std::shared_ptr<t_gnode> gnode, std::string name);
 
     /**

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -421,7 +421,7 @@ namespace binding {
      */
     template <typename CTX_T, typename T>
     T get_from_data_slice(
-        std::shared_ptr<t_data_slice<CTX_T>> data_slice, t_index ridx, t_index cidx);
+        std::shared_ptr<t_data_slice<CTX_T>> data_slice, t_uindex ridx, t_uindex cidx);
 
 } // end namespace binding
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/binding.h
+++ b/cpp/perspective/src/include/perspective/binding.h
@@ -393,6 +393,36 @@ namespace binding {
         std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
         std::uint32_t end_col);
 
+    /**
+     * @brief Get the t_data_slice object, which contains an underlying slice of data and
+     * metadata required to interact with it.
+     *
+     * @param view
+     * @param start_row
+     * @param end_row
+     * @param start_col
+     * @param end_col
+     */
+    template <typename CTX_T>
+    std::shared_ptr<t_data_slice<CTX_T>> get_data_slice(std::shared_ptr<View<CTX_T>> view,
+        std::uint32_t start_row, std::uint32_t end_row, std::uint32_t start_col,
+        std::uint32_t end_col);
+
+    /**
+     * @brief Retrieve a single value from the data slice and serialize it to an output
+     * type that interfaces with the binding language.
+     *
+     * @param view
+     * @param start_row
+     * @param end_row
+     * @param start_col
+     * @param end_col
+     * @return val
+     */
+    template <typename CTX_T, typename T>
+    T get_from_data_slice(
+        std::shared_ptr<t_data_slice<CTX_T>> data_slice, t_index ridx, t_index cidx);
+
 } // end namespace binding
 } // end namespace perspective
 

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -86,7 +86,7 @@ public:
     t_config(const std::vector<std::string>& row_pivots, const t_aggspec& agg);
 
     t_config(const std::vector<t_pivot>& row_pivots, const std::vector<t_aggspec>& aggregates,
-        t_filter_op combiner, const std::vector<t_fterm>& fterms, bool column_only);
+        t_filter_op combiner, const std::vector<t_fterm>& fterms);
 
     t_config(const std::vector<std::string>& row_pivots,
         const std::vector<t_aggspec>& aggregates, t_filter_op combiner,

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -28,21 +28,22 @@ namespace perspective {
  * - m_view: a reference to the view from which we output data
  * - m_slice: a reference to a vector of t_tscalar objects containing data
  * - m_column_names: a reference to a vector of string column names from the view.
- * - m_column_indices: an optional reference to a vector of t_uindex column indices, which
+ * - m_column_indices: an optional reference to a vector of t_index column indices, which
  * we use for column-pivoted views.
  *
  */
 template <typename CTX_T>
 class PERSPECTIVE_EXPORT t_data_slice {
 public:
-    t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
-        t_uindex start_col, t_uindex end_col, std::shared_ptr<std::vector<t_tscalar>> slice,
-        std::shared_ptr<std::vector<std::string>> column_names);
+    t_data_slice(std::shared_ptr<CTX_T> ctx, t_index start_row, t_index end_row,
+        t_index start_col, t_index end_col,
+        const std::shared_ptr<std::vector<t_tscalar>>& slice,
+        std::vector<std::string> column_names);
 
-    t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
-        t_uindex start_col, t_uindex end_col, std::shared_ptr<std::vector<t_tscalar>> slice,
-        std::shared_ptr<std::vector<std::string>> column_names,
-        std::shared_ptr<std::vector<t_uindex>> column_indices);
+    t_data_slice(std::shared_ptr<CTX_T> ctx, t_index start_row, t_index end_row,
+        t_index start_col, t_index end_col,
+        const std::shared_ptr<std::vector<t_tscalar>>& slice,
+        std::vector<std::string> column_names, std::vector<t_index> column_indices);
 
     ~t_data_slice();
 
@@ -56,25 +57,28 @@ public:
      * @return t_tscalar a valid scalar containing the underlying data, or a new
      * t_tscalar initialized with an invalid flag.
      */
-    t_tscalar get(t_uindex ridx, t_uindex cidx) const;
+    t_tscalar get(t_index ridx, t_index cidx) const;
 
-    std::vector<t_tscalar> get_row_path(t_uindex idx) const;
+    std::vector<t_tscalar> get_row_path(t_index idx) const;
+    t_index get_slice_idx(t_index ridx, t_index cidx) const;
 
     std::shared_ptr<CTX_T> get_context() const;
     std::shared_ptr<std::vector<t_tscalar>> get_slice() const;
-    std::shared_ptr<std::vector<std::string>> get_column_names() const;
-    std::shared_ptr<std::vector<t_uindex>> get_column_indices() const;
+    const std::vector<std::string>& get_column_names() const;
+    const std::vector<t_index>& get_column_indices() const;
     t_get_data_extents get_data_extents() const;
+    t_index get_stride() const;
     bool is_column_only() const;
 
 private:
     std::shared_ptr<CTX_T> m_ctx;
-    t_uindex m_start_row;
-    t_uindex m_end_row;
-    t_uindex m_start_col;
-    t_uindex m_end_col;
+    t_index m_start_row;
+    t_index m_end_row;
+    t_index m_start_col;
+    t_index m_end_col;
+    t_index m_stride;
     std::shared_ptr<std::vector<t_tscalar>> m_slice;
-    std::shared_ptr<std::vector<std::string>> m_column_names;
-    std::shared_ptr<std::vector<t_uindex>> m_column_indices;
+    std::vector<std::string> m_column_names;
+    std::vector<t_index> m_column_indices;
 };
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -28,22 +28,22 @@ namespace perspective {
  * - m_view: a reference to the view from which we output data
  * - m_slice: a reference to a vector of t_tscalar objects containing data
  * - m_column_names: a reference to a vector of string column names from the view.
- * - m_column_indices: an optional reference to a vector of t_index column indices, which
+ * - m_column_indices: an optional reference to a vector of t_uindex column indices, which
  * we use for column-pivoted views.
  *
  */
 template <typename CTX_T>
 class PERSPECTIVE_EXPORT t_data_slice {
 public:
-    t_data_slice(std::shared_ptr<CTX_T> ctx, t_index start_row, t_index end_row,
-        t_index start_col, t_index end_col,
+    t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
+        t_uindex start_col, t_uindex end_col,
         const std::shared_ptr<std::vector<t_tscalar>>& slice,
         std::vector<std::string> column_names);
 
-    t_data_slice(std::shared_ptr<CTX_T> ctx, t_index start_row, t_index end_row,
-        t_index start_col, t_index end_col,
+    t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
+        t_uindex start_col, t_uindex end_col,
         const std::shared_ptr<std::vector<t_tscalar>>& slice,
-        std::vector<std::string> column_names, std::vector<t_index> column_indices);
+        std::vector<std::string> column_names, std::vector<t_uindex> column_indices);
 
     ~t_data_slice();
 
@@ -57,28 +57,28 @@ public:
      * @return t_tscalar a valid scalar containing the underlying data, or a new
      * t_tscalar initialized with an invalid flag.
      */
-    t_tscalar get(t_index ridx, t_index cidx) const;
+    t_tscalar get(t_uindex ridx, t_uindex cidx) const;
 
-    std::vector<t_tscalar> get_row_path(t_index idx) const;
-    t_index get_slice_idx(t_index ridx, t_index cidx) const;
+    std::vector<t_tscalar> get_row_path(t_uindex idx) const;
+    t_uindex get_slice_idx(t_uindex ridx, t_uindex cidx) const;
 
     std::shared_ptr<CTX_T> get_context() const;
     std::shared_ptr<std::vector<t_tscalar>> get_slice() const;
     const std::vector<std::string>& get_column_names() const;
-    const std::vector<t_index>& get_column_indices() const;
+    const std::vector<t_uindex>& get_column_indices() const;
     t_get_data_extents get_data_extents() const;
-    t_index get_stride() const;
+    t_uindex get_stride() const;
     bool is_column_only() const;
 
 private:
     std::shared_ptr<CTX_T> m_ctx;
-    t_index m_start_row;
-    t_index m_end_row;
-    t_index m_start_col;
-    t_index m_end_col;
-    t_index m_stride;
+    t_uindex m_start_row;
+    t_uindex m_end_row;
+    t_uindex m_start_col;
+    t_uindex m_end_col;
+    t_uindex m_stride;
     std::shared_ptr<std::vector<t_tscalar>> m_slice;
     std::vector<std::string> m_column_names;
-    std::vector<t_index> m_column_indices;
+    std::vector<t_uindex> m_column_indices;
 };
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -47,8 +47,8 @@ public:
     void set_depth(std::int32_t depth, std::int32_t row_pivot_length);
 
     // Data serialization
-    t_data_slice<CTX_T> get_data(std::uint32_t start_row, std::uint32_t end_row,
-        std::uint32_t start_col, std::uint32_t end_col);
+    std::shared_ptr<t_data_slice<CTX_T>> get_data(
+        t_index start_row, t_index end_row, t_index start_col, t_index end_col);
 
     // Getters
     std::shared_ptr<CTX_T> get_context() const;

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -48,7 +48,7 @@ public:
 
     // Data serialization
     std::shared_ptr<t_data_slice<CTX_T>> get_data(
-        t_index start_row, t_index end_row, t_index start_col, t_index end_col);
+        t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col);
 
     // Getters
     std::shared_ptr<CTX_T> get_context() const;

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -336,15 +336,13 @@ export default function(Module) {
                 for (let cidx = start_col; cidx < end_col; cidx++) {
                     const col_name = col_names[cidx];
                     if (cidx === 0) {
-                        if (!this.column_only) {
-                            let row_path = slice.get_row_path(ridx);
+                        const row_path = slice.get_row_path(ridx);
                         formatter.initColumnValue(data, row, col_name);
                         for (let i = 0; i < row_path.size(); i++) {
-                                const value = clean_data(__MODULE__.scalar_vec_to_val(row_path, i));
+                            const value = __MODULE__.scalar_vec_to_val(row_path, i);
                             formatter.addColumnValue(data, row, col_name, value);
                         }
                         row_path.delete();
-                        }
                     } else {
                         const value = __MODULE__.get_from_data_slice_one(slice, ridx, cidx);
                         formatter.setColumnValue(data, row, col_name, value);

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -311,7 +311,7 @@ export default function(Module) {
         if (this.sides() === 0) {
             slice = __MODULE__.get_data_slice_zero(this._View, start_row, end_row, start_col, end_col);
         } else if (this.sides() === 1) {
-            slice = __MODULE__.get_data_one(this._View, start_row, end_row, start_col, end_col);
+            slice = __MODULE__.get_data_slice_one(this._View, start_row, end_row, start_col, end_col);
         } else {
             slice = __MODULE__.get_data_two(this._View, start_row, end_row, start_col, end_col);
         }
@@ -329,11 +329,37 @@ export default function(Module) {
                 }
                 formatter.addRow(data, row);
             }
+        } else if (this.sides() === 1) {
+            let col_names = extract_vector(slice.get_column_names());
+            col_names.unshift("");
+            for (let ridx = start_row; ridx < end_row; ridx++) {
+                let row = formatter.initRowValue();
+                for (let cidx = start_col; cidx < end_col; cidx++) {
+                    let col_name;
+                    if (cidx === 0) {
+                        if (!this.column_only) {
+                            col_name = "__ROW_PATH__";
+                            let row_path = slice.get_row_path(ridx);
+                            formatter.initColumnValue(data, row, col_name);
+                            for (let i = 0; i < row_path.size(); i++) {
+                                const value = clean_data(__MODULE__.scalar_vec_to_val(row_path, i));
+                                formatter.addColumnValue(data, row, col_name, value);
+                            }
+                            row_path.delete();
+                        }
+                    } else {
+                        col_name = col_names[cidx];
+                        let value = clean_data(__MODULE__.get_from_data_slice_one(slice, ridx, cidx));
+                        formatter.setColumnValue(data, row, col_name, value);
+                    }
+                }
+                formatter.addRow(data, row);
+            }
         } else {
             // determine which level we stop pulling column names
             let skip = false,
                 depth = 0;
-            if (this.sides() == 2 && sorted) {
+            if (sorted) {
                 skip = true;
                 depth = this.config.column_pivot.length;
             }

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -317,15 +317,15 @@ export default function(Module) {
         }
 
         let data = formatter.initDataValue();
-        let row;
 
         if (this.sides() === 0) {
             let col_names = extract_vector(slice.get_column_names());
             for (let ridx = start_row; ridx < end_row; ridx++) {
-                row = formatter.initRowValue();
+                let row = formatter.initRowValue();
                 for (let cidx = start_col; cidx < end_col; cidx++) {
                     let col_name = col_names[cidx];
-                    formatter.setColumnValue(data, row, col_name, __MODULE__.get_from_data_slice_zero(slice, ridx, cidx));
+                    let value = clean_data(__MODULE__.get_from_data_slice_zero(slice, ridx, cidx));
+                    formatter.setColumnValue(data, row, col_name, value);
                 }
                 formatter.addRow(data, row);
             }
@@ -338,6 +338,7 @@ export default function(Module) {
                 depth = this.config.column_pivot.length;
             }
             let col_names = [[]].concat(this._column_names(skip, depth));
+            let row;
             let ridx = -1;
             for (let idx = 0; idx < slice.length; idx++) {
                 let cidx = idx % Math.min(end_col - start_col, col_names.slice(start_col, end_col - start_col + 1).length);

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -8,7 +8,7 @@
  */
 
 import * as defaults from "./defaults.js";
-import {DataAccessor, clean_data} from "./DataAccessor/DataAccessor.js";
+import {DataAccessor} from "./DataAccessor/DataAccessor.js";
 import {DateParser} from "./DataAccessor/DateParser.js";
 import {extract_map, extract_vector} from "./emscripten.js";
 import {bindall, get_column_type} from "./utils.js";
@@ -319,37 +319,34 @@ export default function(Module) {
         let data = formatter.initDataValue();
 
         if (this.sides() === 0) {
-            let col_names = extract_vector(slice.get_column_names());
+            const col_names = extract_vector(slice.get_column_names());
             for (let ridx = start_row; ridx < end_row; ridx++) {
-                let row = formatter.initRowValue();
+                const row = formatter.initRowValue();
                 for (let cidx = start_col; cidx < end_col; cidx++) {
-                    let col_name = col_names[cidx];
-                    let value = clean_data(__MODULE__.get_from_data_slice_zero(slice, ridx, cidx));
+                    const col_name = col_names[cidx];
+                    const value = __MODULE__.get_from_data_slice_zero(slice, ridx, cidx);
                     formatter.setColumnValue(data, row, col_name, value);
                 }
                 formatter.addRow(data, row);
             }
         } else if (this.sides() === 1) {
-            let col_names = extract_vector(slice.get_column_names());
-            col_names.unshift("");
+            const col_names = extract_vector(slice.get_column_names());
             for (let ridx = start_row; ridx < end_row; ridx++) {
-                let row = formatter.initRowValue();
+                const row = formatter.initRowValue();
                 for (let cidx = start_col; cidx < end_col; cidx++) {
-                    let col_name;
+                    const col_name = col_names[cidx];
                     if (cidx === 0) {
                         if (!this.column_only) {
-                            col_name = "__ROW_PATH__";
                             let row_path = slice.get_row_path(ridx);
-                            formatter.initColumnValue(data, row, col_name);
-                            for (let i = 0; i < row_path.size(); i++) {
+                        formatter.initColumnValue(data, row, col_name);
+                        for (let i = 0; i < row_path.size(); i++) {
                                 const value = clean_data(__MODULE__.scalar_vec_to_val(row_path, i));
-                                formatter.addColumnValue(data, row, col_name, value);
-                            }
-                            row_path.delete();
+                            formatter.addColumnValue(data, row, col_name, value);
+                        }
+                        row_path.delete();
                         }
                     } else {
-                        col_name = col_names[cidx];
-                        let value = clean_data(__MODULE__.get_from_data_slice_one(slice, ridx, cidx));
+                        const value = __MODULE__.get_from_data_slice_one(slice, ridx, cidx);
                         formatter.setColumnValue(data, row, col_name, value);
                     }
                 }
@@ -379,14 +376,14 @@ export default function(Module) {
                         let row_path = this._View.get_row_path(start_row + ridx);
                         formatter.initColumnValue(data, row, col_name);
                         for (let i = 0; i < row_path.size(); i++) {
-                            const value = clean_data(__MODULE__.scalar_vec_to_val(row_path, i));
+                            const value = __MODULE__.scalar_vec_to_val(row_path, i);
                             formatter.addColumnValue(data, row, col_name, value);
                         }
                         row_path.delete();
                     }
                 } else {
                     let col_name = col_names[start_col + cidx];
-                    formatter.setColumnValue(data, row, col_name, clean_data(slice[idx]));
+                    formatter.setColumnValue(data, row, col_name, slice[idx]);
                 }
             }
 

--- a/packages/perspective/test/js/to_format.js
+++ b/packages/perspective/test/js/to_format.js
@@ -15,6 +15,31 @@ var int_float_string_data = [
 ];
 
 module.exports = perspective => {
+    describe("data slice", function() {
+        it("data slice should respect start/end rows", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view();
+            let json = await view.to_json({
+                start_row: 2,
+                end_row: 3
+            });
+            let comparator = int_float_string_data[2];
+            comparator.datetime = +comparator.datetime;
+            expect(json[0]).toEqual(comparator);
+        });
+
+        it("data slice should respect start/end columns", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view();
+            let json = await view.to_columns({
+                start_col: 2,
+                end_col: 3
+            });
+            let comparator = {string: int_float_string_data.map(d => d.string)};
+            expect(json).toEqual(comparator);
+        });
+    });
+
     describe("to_json", function() {
         it("should emit same number of column names as number of pivots", async function() {
             let table = perspective.table(int_float_string_data);

--- a/packages/perspective/test/js/to_format.js
+++ b/packages/perspective/test/js/to_format.js
@@ -38,6 +38,40 @@ module.exports = perspective => {
             let comparator = {string: int_float_string_data.map(d => d.string)};
             expect(json).toEqual(comparator);
         });
+
+        it("one-sided views should have row paths", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view({
+                row_pivot: ["int"]
+            });
+            let json = await view.to_json();
+            for (let d of json) {
+                expect(d.__ROW_PATH__).toBeDefined();
+            }
+        });
+
+        it("one-sided column-only views should not have row paths", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view({
+                column_pivot: ["int"]
+            });
+            let json = await view.to_json();
+            for (let d of json) {
+                expect(d.__ROW_PATH__).toBeUndefined();
+            }
+        });
+
+        it("two-sided views should have row paths", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view({
+                row_pivot: ["int"],
+                column_pivot: ["string"]
+            });
+            let json = await view.to_json();
+            for (let d of json) {
+                expect(d.__ROW_PATH__).toBeDefined();
+            }
+        });
     });
 
     describe("to_json", function() {


### PR DESCRIPTION
This PR implements the new data_slice API for zero and one-sided views. Benchmarking shows a consistent 10-15% improvement in calls to `to_json`, but I'd love to have that validated on other machines.

Changes:
- `t_data_slice` allows for data extraction with bounds checking; this solves an issue with `perspective-hypergrid` calling `get_columns` with row indices that were larger than the number of rows within the engine. The use of `at()` instead of `operator[]`, IIRC, should prevent undefined behavior from occurring when we index into the underlying slice. @texodus @timkpaine please look over this closely if possible.
- `perspective.js` now pulls column names and row paths from the data slice, instead of making calls to the underlying C++ view.
- Shared pointers are used for the `data_slice` and underlying slice vector, but other metadata are stored as copies and returned as `const` references in order to make it easier to interface with from the JS binding.