### PR TITLE
Fully implement data slice API

### DIFF
--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -46,8 +46,8 @@ template <typename CTX_T>
 t_data_slice<CTX_T>::~t_data_slice() {}
 
 /**
- * @brief Returns the t_tscalar at the declared indices in the data slice,
- * or an invalid t_tscalar if the indices should be skipped.
+ * @brief Returns the t_tscalar for the row/column in the data slice.
+ * If the row/column index is invalid, return a null-initialized t_tscalar.
  *
  * @param ridx row index into the slice
  * @param cidx column index into the slice
@@ -65,29 +65,6 @@ t_data_slice<CTX_T>::get(t_uindex ridx, t_uindex cidx) const {
     } else {
         rv = m_slice->at(idx);
     }
-    return rv;
-}
-
-template <>
-t_tscalar
-t_data_slice<t_ctx2>::get(t_uindex ridx, t_uindex cidx) const {
-    t_uindex idx = get_slice_idx(ridx, cidx);
-    t_tscalar rv;
-
-    if (m_column_indices.size() > 0) {
-        auto skip_cidx = std::find(m_column_indices.begin(), m_column_indices.end(), cidx);
-        if (skip_cidx == m_column_indices.end()) {
-            rv.clear();
-            return rv;
-        }
-    }
-
-    if (idx >= m_slice->size()) {
-        rv.clear();
-    } else {
-        rv = m_slice->at(idx);
-    }
-
     return rv;
 }
 

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -54,7 +54,7 @@ t_data_slice<CTX_T>::get(t_uindex ridx, t_uindex cidx) const {
     if (idx >= m_slice->size()) {
         rv.clear();
     } else {
-        rv = m_slice->at(idx);
+        rv = m_slice->operator[](idx);
     }
     return rv;
 }

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -45,16 +45,7 @@ t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row
 template <typename CTX_T>
 t_data_slice<CTX_T>::~t_data_slice() {}
 
-/**
- * @brief Returns the t_tscalar for the row/column in the data slice.
- * If the row/column index is invalid, return a null-initialized t_tscalar.
- *
- * @param ridx row index into the slice
- * @param cidx column index into the slice
- *
- * @return t_tscalar a valid scalar containing the underlying data, or a new
- * t_tscalar initialized with an invalid flag.
- */
+// Public API
 template <typename CTX_T>
 t_tscalar
 t_data_slice<CTX_T>::get(t_uindex ridx, t_uindex cidx) const {
@@ -70,15 +61,8 @@ t_data_slice<CTX_T>::get(t_uindex ridx, t_uindex cidx) const {
 
 template <typename CTX_T>
 std::vector<t_tscalar>
-t_data_slice<CTX_T>::get_row_path(t_uindex idx) const {
-    return m_ctx->unity_get_row_path(idx);
-}
-
-template <typename CTX_T>
-t_uindex
-t_data_slice<CTX_T>::get_slice_idx(t_uindex ridx, t_uindex cidx) const {
-    t_uindex idx = (ridx - m_start_row) * m_stride + (cidx - m_start_col);
-    return idx;
+t_data_slice<CTX_T>::get_row_path(t_uindex ridx) const {
+    return m_ctx->unity_get_row_path(ridx);
 }
 
 // Getters
@@ -133,6 +117,14 @@ t_data_slice<CTX_T>::get_data_extents() const {
     t_get_data_extents ext = sanitize_get_data_extents(
         nrows, ncols, m_start_row, m_end_row, m_start_col, m_end_col);
     return ext;
+}
+
+// Private
+template <typename CTX_T>
+t_uindex
+t_data_slice<CTX_T>::get_slice_idx(t_uindex ridx, t_uindex cidx) const {
+    t_uindex idx = (ridx - m_start_row) * m_stride + (cidx - m_start_col);
+    return idx;
 }
 
 // Explicitly instantiate data slice for each context

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -72,12 +72,22 @@ template <>
 t_tscalar
 t_data_slice<t_ctx2>::get(t_uindex ridx, t_uindex cidx) const {
     t_uindex idx = get_slice_idx(ridx, cidx);
-    t_tscalar rv = m_slice->operator[](idx);
-    /* if (m_column_indices.size() > 0) {
-        t_uindex idx_skip_headers;
-    } else {
+    t_tscalar rv;
 
-    } */
+    if (m_column_indices.size() > 0) {
+        auto skip_cidx = std::find(m_column_indices.begin(), m_column_indices.end(), cidx);
+        if (skip_cidx == m_column_indices.end()) {
+            rv.clear();
+            return rv;
+        }
+    }
+
+    if (idx >= m_slice->size()) {
+        rv.clear();
+    } else {
+        rv = m_slice->at(idx);
+    }
+
     return rv;
 }
 

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1928,6 +1928,8 @@ namespace binding {
         auto column_indices = data_slice->get_column_indices();
 
         if (column_indices.size() > 0) {
+            // for every column, go through the slice and pick out exactly what pieces of data
+            // belong to that column. Set them sequentially in the new array.
             t_uindex i = 0;
             auto iter = slice->begin();
             while (iter != slice->end()) {

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -2150,7 +2150,8 @@ EMSCRIPTEN_BINDINGS(perspective) {
     class_<t_data_slice<t_ctx2>>("t_data_slice_ctx2")
         .smart_ptr<std::shared_ptr<t_data_slice<t_ctx2>>>("shared_ptr<t_data_slice<t_ctx2>>>")
         .function<const std::vector<std::string>&>(
-            "get_column_names", &t_data_slice<t_ctx2>::get_column_names);
+            "get_column_names", &t_data_slice<t_ctx2>::get_column_names)
+        .function<std::vector<t_tscalar>>("get_row_path", &t_data_slice<t_ctx2>::get_row_path);
 
     /******************************************************************************
      *

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1882,78 +1882,6 @@ namespace binding {
     }
 
     /**
-     * @brief Get a slice of data foe each column from the underlying view,
-     * serialized to val.
-     *
-     * @tparam CTX_T
-     * @param view
-     * @param start_row
-     * @param end_row
-     * @param start_col
-     * @param end_col
-     * @return val
-     */
-    template <typename CTX_T>
-    val
-    get_data(std::shared_ptr<View<CTX_T>> view, std::uint32_t start_row, std::uint32_t end_row,
-        std::uint32_t start_col, std::uint32_t end_col) {
-        val arr = val::array();
-        auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
-        auto slice = data_slice->get_slice();
-        for (auto idx = 0; idx < slice->size(); ++idx) {
-            arr.set(idx, scalar_to_val(slice->at(idx)));
-        }
-        return arr;
-    }
-
-    /**
-     * @brief Get a slice of data from the underlying view, serlializing to val
-     * and, for sorted views, ignoring the sort headers which aren't part of the
-     * underlying data.
-     *
-     * @param view
-     * @param start_row
-     * @param end_row
-     * @param start_col
-     * @param end_col
-     * @return val
-     */
-    template <>
-    val
-    get_data(std::shared_ptr<View<t_ctx2>> view, std::uint32_t start_row, std::uint32_t end_row,
-        std::uint32_t start_col, std::uint32_t end_col) {
-        val arr = val::array();
-        auto data_slice = view->get_data(start_row, end_row, start_col, end_col);
-        auto slice = data_slice->get_slice();
-        auto column_indices = data_slice->get_column_indices();
-
-        if (column_indices.size() > 0) {
-            // for every column, go through the slice and pick out exactly what pieces of data
-            // belong to that column. Set them sequentially in the new array.
-            t_uindex i = 0;
-            auto iter = slice->begin();
-            while (iter != slice->end()) {
-                t_uindex prev = column_indices.front();
-                for (auto idx = column_indices.begin(); idx != column_indices.end();
-                     idx++, i++) {
-                    t_uindex col_num = *idx;
-                    iter += col_num - prev;
-                    prev = col_num;
-                    arr.set(i, scalar_to_val(*iter));
-                }
-                if (iter != slice->end())
-                    iter++;
-            }
-        } else {
-            for (auto idx = 0; idx < slice->size(); ++idx) {
-                arr.set(idx, scalar_to_val(slice->at(idx)));
-            }
-        }
-
-        return arr;
-    }
-
-    /**
      * @brief Get the t_data_slice object, which contains an underlying slice of data and
      * metadata required to interact with it.
      *
@@ -2279,9 +2207,6 @@ EMSCRIPTEN_BINDINGS(perspective) {
     function("clone_gnode_table", &clone_gnode_table<val>, allow_raw_pointers());
     function("scalar_vec_to_val", &scalar_vec_to_val);
     function("table_add_computed_column", &table_add_computed_column<val>);
-    function("get_data_zero", &get_data<t_ctx0>);
-    function("get_data_one", &get_data<t_ctx1>);
-    function("get_data_two", &get_data<t_ctx2>);
     function("col_to_js_typed_array_zero", &col_to_js_typed_array<t_ctx0>);
     function("col_to_js_typed_array_one", &col_to_js_typed_array<t_ctx1>);
     function("col_to_js_typed_array_two", &col_to_js_typed_array<t_ctx2>);

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -85,7 +85,15 @@ template <>
 std::int32_t
 View<t_ctx2>::num_columns() const {
     if (m_sorts.size() > 0) {
-        return m_ctx->unity_get_column_count() - m_aggregates.size();
+        auto depth = m_column_pivots.size();
+        auto col_length = m_ctx->unity_get_column_count();
+        auto count = 0;
+        for (t_uindex i = 0; i < col_length; ++i) {
+            if (m_ctx->unity_get_column_path(i + 1).size() == depth) {
+                count++;
+            }
+        }
+        return count;
     } else {
         return m_ctx->unity_get_column_count();
     }

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -357,6 +357,7 @@ View<t_ctx2>::get_data(
         slice = m_ctx->get_data(start_row, end_row, start_col, end_col);
     }
 
+    column_names.insert(column_names.begin(), "__ROW_PATH__");
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(slice);
     auto data_slice_ptr = std::make_shared<t_data_slice<t_ctx2>>(
         m_ctx, start_row, end_row, start_col, end_col, slice_ptr, column_names, column_indices);

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -23,7 +23,11 @@ namespace perspective {
  * @class t_data_slice
  *
  * @brief t_data_slice contains a slice of the View's underlying data
- * with the metadata required to correctly parse it.
+ * with the metadata required to correctly parse it. It offers a unified get(row_index,
+ * col_index) API that is extensible and does not require additional parsing in the binding
+ * language. This makes implementing data serialization easy, as one simply writes each row and
+ * each column inside it sequentially.
+ *
  *
  * - m_view: a reference to the view from which we output data
  * - m_slice: a reference to a vector of t_tscalar objects containing data
@@ -59,9 +63,16 @@ public:
      */
     t_tscalar get(t_uindex ridx, t_uindex cidx) const;
 
-    std::vector<t_tscalar> get_row_path(t_uindex idx) const;
-    t_uindex get_slice_idx(t_uindex ridx, t_uindex cidx) const;
+    /**
+     * @brief Returns the row path, which maps a specific piece of data to the
+     * row and column that it belongs to.
+     *
+     * @param ridx the row index into the slice
+     * @return std::vector<t_tscalar>
+     */
+    std::vector<t_tscalar> get_row_path(t_uindex ridx) const;
 
+    // Getters
     std::shared_ptr<CTX_T> get_context() const;
     std::shared_ptr<std::vector<t_tscalar>> get_slice() const;
     const std::vector<std::string>& get_column_names() const;
@@ -71,6 +82,16 @@ public:
     bool is_column_only() const;
 
 private:
+    /**
+     * @brief Calculates the index into the underlying data slice for the
+     * row and the column.
+     *
+     * @param ridx
+     * @param cidx
+     * @return t_uindex
+     */
+    t_uindex get_slice_idx(t_uindex ridx, t_uindex cidx) const;
+
     std::shared_ptr<CTX_T> m_ctx;
     t_uindex m_start_row;
     t_uindex m_end_row;

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -33,26 +33,106 @@ public:
 
     ~View();
 
+    /**
+     * @brief The number of pivoted sides of this View.
+     *
+     * @return std::int32_t
+     */
     std::int32_t sides() const;
+
+    /**
+     * @brief The number of aggregated rows in this View. This is affected by
+     * the "row_pivot" configuration parameter supplied to this View's
+     * contructor.
+     *
+     *
+     * @return std::int32_t the number of aggregated rows
+     */
     std::int32_t num_rows() const;
+
+    /**
+     * @brief The number of aggregated columns in this View. This is affected by
+     * the "column_pivot" configuration parameter supplied to this View's
+     * contructor.
+     *
+     *
+     * @return std::int32_t the number of aggregated columns
+     */
     std::int32_t num_columns() const;
 
+    /**
+     * @brief The schema of this View.  A schema is an std::map, the keys of which
+     * are the columns of this View, and the values are their string type names.
+     * If this View is aggregated, theses will be the aggregated types;
+     * otherwise these types will be the same as the columns in the underlying
+     * Table.
+     *
+     * @return std::map<std::string, std::string>
+     */
     std::map<std::string, std::string> schema() const;
+
+    /**
+     * @brief The column names of this View. If the View is aggregated, the
+     * individual column names will be joined with a separator character
+     * specified by the user, or defaulting to "|".
+     *
+     * @return std::vector<std::string>
+     */
     std::vector<std::string> _column_names(bool skip = false, std::int32_t depth = 0) const;
 
-    // Pivot table operations
-    std::int32_t get_row_expanded(std::int32_t idx) const;
-    t_index expand(std::int32_t idx, std::int32_t row_pivot_length);
-    t_index collapse(std::int32_t idx);
-    void set_depth(std::int32_t depth, std::int32_t row_pivot_length);
-
-    // Data serialization
+    /**
+     * @brief Returns shared pointer to a t_data_slice object, which contains the
+     * underlying slice of data as well as the metadata required to interface
+     * with it.
+     *
+     * @tparam
+     * @param start_row
+     * @param end_row
+     * @param start_col
+     * @param end_col
+     * @return std::shared_ptr<t_data_slice<t_ctx0>>
+     */
     std::shared_ptr<t_data_slice<CTX_T>> get_data(
         t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col);
 
     // Delta calculation
     bool _get_deltas_enabled() const;
     void _set_deltas_enabled(bool enabled_state);
+
+    // Pivot table operations
+
+    /**
+     * @brief Whether the row at "ridx" is expanded or collapsed.
+     *
+     * @param ridx
+     * @return std::int32_t
+     */
+    std::int32_t get_row_expanded(std::int32_t ridx) const;
+
+    /**
+     * @brief Expands the row at "ridx".
+     *
+     * @param ridx
+     * @param row_pivot_length
+     * @return t_index
+     */
+    t_index expand(std::int32_t ridx, std::int32_t row_pivot_length);
+
+    /**
+     * @brief Collapses the row at "ridx".
+     *
+     * @param ridx
+     * @return t_index
+     */
+    t_index collapse(std::int32_t ridx);
+
+    /**
+     * @brief Set the expansion "depth" of the pivot tree.
+     *
+     * @param depth
+     * @param row_pivot_length
+     */
+    void set_depth(std::int32_t depth, std::int32_t row_pivot_length);
 
     // Getters
     std::shared_ptr<CTX_T> get_context() const;

--- a/packages/perspective-viewer/src/js/utils.js
+++ b/packages/perspective-viewer/src/js/utils.js
@@ -172,7 +172,6 @@ function _attribute(_default) {
         };
         delete desc["value"];
         delete desc["writable"];
-        console.log(desc);
         return desc;
     };
 }

--- a/packages/perspective-viewer/test/js/simple_tests.js
+++ b/packages/perspective-viewer/test/js/simple_tests.js
@@ -46,16 +46,6 @@ exports.default = function() {
         await page.evaluate(element => element.setAttribute("column-pivots", '["Category","Sub-Category"]'), viewer);
     });
 
-    test.skip("pivots by two rows and two columns, sorted by a numeric column.", async page => {
-        const viewer = await page.$("perspective-viewer");
-        await page.shadow_click("perspective-viewer", "#config_button");
-        await page.evaluate(element => element.setAttribute("row-pivots", '["Region","State"]'), viewer);
-        await page.waitForSelector("perspective-viewer:not([updating])");
-        await page.evaluate(element => element.setAttribute("column-pivots", '["Category","Sub-Category"]'), viewer);
-        await page.waitForSelector("perspective-viewer:not([updating])");
-        await page.evaluate(element => element.setAttribute("sort", '[["Sales", "desc"]]'), viewer);
-    });
-
     test.capture("sorts by a hidden column.", async page => {
         const viewer = await page.$("perspective-viewer");
         await page.shadow_click("perspective-viewer", "#config_button");

--- a/packages/perspective-viewer/test/js/simple_tests.js
+++ b/packages/perspective-viewer/test/js/simple_tests.js
@@ -46,6 +46,16 @@ exports.default = function() {
         await page.evaluate(element => element.setAttribute("column-pivots", '["Category","Sub-Category"]'), viewer);
     });
 
+    test.skip("pivots by two rows and two columns, sorted by a numeric column.", async page => {
+        const viewer = await page.$("perspective-viewer");
+        await page.shadow_click("perspective-viewer", "#config_button");
+        await page.evaluate(element => element.setAttribute("row-pivots", '["Region","State"]'), viewer);
+        await page.waitForSelector("perspective-viewer:not([updating])");
+        await page.evaluate(element => element.setAttribute("column-pivots", '["Category","Sub-Category"]'), viewer);
+        await page.waitForSelector("perspective-viewer:not([updating])");
+        await page.evaluate(element => element.setAttribute("sort", '[["Sales", "desc"]]'), viewer);
+    });
+
     test.capture("sorts by a hidden column.", async page => {
         const viewer = await page.$("perspective-viewer");
         await page.shadow_click("perspective-viewer", "#config_button");

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -315,7 +315,7 @@ export default function(Module) {
 
         const viewport = this.config.viewport ? this.config.viewport : {};
         const start_row = options.start_row || (viewport.top ? viewport.top : 0);
-        const end_row = (options.end_row || (viewport.height ? start_row + viewport.height : max_rows)) + (this.column_only ? this.config.column_pivot.length : 0);
+        const end_row = (options.end_row || (viewport.height ? start_row + viewport.height : max_rows)) + (this.column_only ? 1 : 0);
         const start_col = options.start_col || (viewport.left ? viewport.left : 0);
         const end_col = Math.min(max_cols, options.end_col || (viewport.width ? start_col + viewport.width : max_cols));
 
@@ -350,7 +350,7 @@ export default function(Module) {
         }
 
         if (this.column_only) {
-            data = formatter.slice(data, this.config.column_pivot.length);
+            data = formatter.slice(data, 1);
         }
 
         return formatter.formatData(data, options.config);

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -340,7 +340,7 @@ export default function(Module) {
             let row = formatter.initRowValue();
             for (let cidx = start_col; cidx < end_col; cidx++) {
                 const col_name = col_names[cidx];
-                if (cidx === 0 && num_sides !== 0) {
+                if (cidx === start_col && num_sides !== 0) {
                     if (!this.column_only) {
                         const row_path = slice.get_row_path(ridx);
                         formatter.initColumnValue(data, row, "__ROW_PATH__");

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -574,8 +574,8 @@ export default function(Module) {
     };
 
     /**
-     * The number of aggregated columns in this {@link module:perspective~view}.  This is affected by
-     * the "column_pivots" configuration parameter supplied to this {@link module:perspective~view}'s
+     * The number of aggregated columns in this {@link view}.  This is affected by
+     * the "column_pivot" configuration parameter supplied to this {@link view}'s
      * contructor.
      *
      * @async

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -629,7 +629,7 @@ export default function(Module) {
 
     /**
      * Returns the data of all changed rows in JSON format, or for 1+ sided contexts
-     * an empty array as the feature has not been enabled due to performance concerns.
+     * the entire dataset of the view.
      * @private
      */
     view.prototype._get_step_delta = async function() {

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -591,6 +591,23 @@ module.exports = perspective => {
             view.delete();
             table.delete();
         });
+
+        it("['x', 'z']", async function() {
+            var table = perspective.table(data);
+            var view = table.view({
+                column_pivot: ["x", "z"],
+                aggregate: [{column: "y", op: "sum"}]
+            });
+            let result2 = await view.to_json();
+            expect(result2).toEqual([
+                {"1|true|y": "a", "2|false|y": null, "3|true|y": null, "4|false|y": null},
+                {"1|true|y": null, "2|false|y": "b", "3|true|y": null, "4|false|y": null},
+                {"1|true|y": null, "2|false|y": null, "3|true|y": "c", "4|false|y": null},
+                {"1|true|y": null, "2|false|y": null, "3|true|y": null, "4|false|y": "d"}
+            ]);
+            view.delete();
+            table.delete();
+        });
     });
 
     describe("Expand/Collapse", function() {

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -491,7 +491,7 @@ module.exports = perspective => {
     });
 
     describe("Column pivot", function() {
-        it("['x'] only, schema", async function() {
+        it("['y'] only, schema", async function() {
             var table = perspective.table(data);
             var view = table.view({
                 column_pivot: ["y"]
@@ -518,7 +518,7 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it("['x'] only, column-oriented output", async function() {
+        it("['z'] only, column-oriented output", async function() {
             var table = perspective.table(data_7);
             var view = table.view({
                 column_pivot: ["z"]
@@ -538,7 +538,25 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it("['x'] only", async function() {
+        it("['y'] only sorted by ['x'] desc", async function() {
+            var table = perspective.table(data);
+            var view = table.view({
+                column_pivot: ["y"],
+                sort: [["x", "desc"]]
+            });
+            var answer = [
+                {"a|x": null, "a|y": null, "a|z": null, "b|x": null, "b|y": null, "b|z": null, "c|x": null, "c|y": null, "c|z": null, "d|x": 4, "d|y": "d", "d|z": false},
+                {"a|x": null, "a|y": null, "a|z": null, "b|x": null, "b|y": null, "b|z": null, "c|x": 3, "c|y": "c", "c|z": true, "d|x": null, "d|y": null, "d|z": null},
+                {"a|x": null, "a|y": null, "a|z": null, "b|x": 2, "b|y": "b", "b|z": false, "c|x": null, "c|y": null, "c|z": null, "d|x": null, "d|y": null, "d|z": null},
+                {"a|x": 1, "a|y": "a", "a|z": true, "b|x": null, "b|y": null, "b|z": null, "c|x": null, "c|y": null, "c|z": null, "d|x": null, "d|y": null, "d|z": null}
+            ];
+            let result2 = await view.to_json();
+            expect(result2).toEqual(answer);
+            view.delete();
+            table.delete();
+        });
+
+        it("['y'] only", async function() {
             var table = perspective.table(data);
             var view = table.view({
                 column_pivot: ["y"]
@@ -671,6 +689,19 @@ module.exports = perspective => {
 
             let result2 = await view.to_columns();
             expect(Object.keys(result2)).toEqual(["__ROW_PATH__", "C|x", "C|y", "B|x", "B|y", "A|x", "A|y"]);
+            view.delete();
+            table.delete();
+        });
+
+        it("['y'] by ['x'] sorted by ['x'] desc has the correct # of columns", async function() {
+            var table = perspective.table(data);
+            var view = table.view({
+                column_pivot: ["y"],
+                row_pivot: ["x"],
+                sort: [["x", "desc"]]
+            });
+            let num_cols = await view.num_columns();
+            expect(num_cols).toEqual(12);
             view.delete();
             table.delete();
         });

--- a/packages/perspective/test/js/to_format.js
+++ b/packages/perspective/test/js/to_format.js
@@ -83,6 +83,31 @@ module.exports = perspective => {
                 expect(d.__ROW_PATH__).toBeDefined();
             }
         });
+
+        it("two-sided views with start_col > 0 should have row paths", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view({
+                row_pivot: ["int"],
+                column_pivot: ["string"]
+            });
+            let json = await view.to_json({start_col: 1});
+            for (let d of json) {
+                expect(d.__ROW_PATH__).toBeDefined();
+            }
+        });
+
+        it("two-sided sorted views with start_col > 0 should have row paths", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view({
+                row_pivot: ["int"],
+                column_pivot: ["string"],
+                sort: [["string", "desc"]]
+            });
+            let json = await view.to_json({start_col: 1});
+            for (let d of json) {
+                expect(d.__ROW_PATH__).toBeDefined();
+            }
+        });
     });
 
     describe("to_json", function() {


### PR DESCRIPTION
This PR implements the `t_data_slice` API in use for 0 and 1-sided contexts, and fully integrates it into `perspective.js` and 2-sided contexts. It correctly skips header rows for sorted 2-sided contexts, and provides a unified `get(row_index, col_index)` API. This allows data serialization to be easily implemented and extensible.

- Data slice works for 2-sided views
- `t_data_slice` and `View` are documented in the header files
- additional tests to prevent regression