### PR TITLE
API Refactor

### DIFF
--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -86,11 +86,12 @@ t_config::t_config(const std::vector<t_pivot>& row_pivots,
 // view config
 t_config::t_config(const std::vector<std::string>& row_pivots,
     const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates,
-    const std::vector<t_sortspec>& sortspecs, t_filter_op combiner,
+    const std::vector<t_sortspec>& sortspecs, const std::vector<t_sortspec>& col_sortspecs, t_filter_op combiner,
     const std::vector<t_fterm>& fterms, const std::vector<std::string>& col_names,
     bool column_only)
     : m_column_only(column_only)
     , m_sortspecs(sortspecs)
+    , m_col_sortspecs(col_sortspecs)
     , m_aggregates(aggregates)
     , m_detail_columns(col_names)
     , m_combiner(combiner)
@@ -428,6 +429,11 @@ t_config::get_sortby_pairs() const {
 const std::vector<t_sortspec>&
 t_config::get_sortspecs() const {
     return m_sortspecs;
+}
+
+const std::vector<t_sortspec>&
+t_config::get_col_sortspecs() const {
+    return m_col_sortspecs;
 }
 
 const std::vector<t_aggspec>&

--- a/cpp/perspective/src/cpp/config.cpp
+++ b/cpp/perspective/src/cpp/config.cpp
@@ -86,9 +86,9 @@ t_config::t_config(const std::vector<t_pivot>& row_pivots,
 // view config
 t_config::t_config(const std::vector<std::string>& row_pivots,
     const std::vector<std::string>& col_pivots, const std::vector<t_aggspec>& aggregates,
-    const std::vector<t_sortspec>& sortspecs, const std::vector<t_sortspec>& col_sortspecs, t_filter_op combiner,
-    const std::vector<t_fterm>& fterms, const std::vector<std::string>& col_names,
-    bool column_only)
+    const std::vector<t_sortspec>& sortspecs, const std::vector<t_sortspec>& col_sortspecs,
+    t_filter_op combiner, const std::vector<t_fterm>& fterms,
+    const std::vector<std::string>& col_names, bool column_only)
     : m_column_only(column_only)
     , m_sortspecs(sortspecs)
     , m_col_sortspecs(col_sortspecs)

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1590,8 +1590,8 @@ namespace binding {
     t_config
     make_view_config(
         const t_schema& schema, std::string separator, val date_parser, val config) {
-        val j_row_pivot = config["row_pivot"];
-        val j_column_pivot = config["column_pivot"];
+        val j_row_pivot = config["row_pivots"];
+        val j_column_pivot = config["column_pivots"];
         val j_aggregate = config["aggregate"];
         val j_filter = config["filter"];
         val j_sort = config["sort"];

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1645,8 +1645,8 @@ namespace binding {
             col_sorts = _get_sort(col_names, true, j_sort);
         }
 
-        auto view_config = t_config(row_pivots, column_pivots, aggregates, sorts, col_sorts, filter_op,
-            filters, col_names, column_only);
+        auto view_config = t_config(row_pivots, column_pivots, aggregates, sorts, col_sorts,
+            filter_op, filters, col_names, column_only);
 
         return view_config;
     }

--- a/cpp/perspective/src/cpp/emscripten.cpp
+++ b/cpp/perspective/src/cpp/emscripten.cpp
@@ -1601,6 +1601,7 @@ namespace binding {
         std::vector<t_aggspec> aggregates;
         std::vector<t_fterm> filters;
         std::vector<t_sortspec> sorts;
+        std::vector<t_sortspec> col_sorts;
 
         t_filter_op filter_op = t_filter_op::FILTER_OP_AND;
 
@@ -1641,9 +1642,10 @@ namespace binding {
 
         if (hasValue(j_sort)) {
             sorts = _get_sort(col_names, false, j_sort);
+            col_sorts = _get_sort(col_names, true, j_sort);
         }
 
-        auto view_config = t_config(row_pivots, column_pivots, aggregates, sorts, filter_op,
+        auto view_config = t_config(row_pivots, column_pivots, aggregates, sorts, col_sorts, filter_op,
             filters, col_names, column_only);
 
         return view_config;
@@ -1722,6 +1724,7 @@ namespace binding {
         auto filter_op = view_config.get_combiner();
         auto filters = view_config.get_fterms();
         auto sorts = view_config.get_sortspecs();
+        auto col_sorts = view_config.get_col_sortspecs();
 
         std::int32_t rpivot_depth = -1;
         std::int32_t cpivot_depth = -1;
@@ -1732,12 +1735,6 @@ namespace binding {
 
         if (hasValue(config["column_pivot_depth"])) {
             cpivot_depth = config["column_pivot_depth"].as<std::int32_t>();
-        }
-
-        val j_sort = config["sort"];
-        std::vector<t_sortspec> col_sorts;
-        if (hasValue(j_sort)) {
-            col_sorts = _get_sort(column_names, true, j_sort);
         }
 
         auto ctx = make_context_two(schema, row_pivots, column_pivots, filter_op, filters,

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -58,9 +58,9 @@ public:
     // view config
     t_config(const std::vector<std::string>& row_pivots,
         const std::vector<std::string>& column_pivots, const std::vector<t_aggspec>& aggregates,
-        const std::vector<t_sortspec>& sortspecs, const std::vector<t_sortspec>& col_sortspecs, t_filter_op combiner,
-        const std::vector<t_fterm>& fterms, const std::vector<std::string>& col_names,
-        bool column_only);
+        const std::vector<t_sortspec>& sortspecs, const std::vector<t_sortspec>& col_sortspecs,
+        t_filter_op combiner, const std::vector<t_fterm>& fterms,
+        const std::vector<std::string>& col_names, bool column_only);
 
     // grouped_pkeys
     t_config(const std::vector<std::string>& row_pivots,

--- a/cpp/perspective/src/include/perspective/config.h
+++ b/cpp/perspective/src/include/perspective/config.h
@@ -26,6 +26,7 @@ struct PERSPECTIVE_EXPORT t_config_recipe {
     std::vector<t_pivot_recipe> m_row_pivots;
     std::vector<t_pivot_recipe> m_col_pivots;
     std::vector<std::pair<std::string, std::string>> m_sortby;
+    std::vector<std::pair<std::string, std::string>> m_col_sortby;
     std::vector<t_aggspec_recipe> m_aggregates;
     std::vector<std::string> m_detail_columns;
     t_totals m_totals;
@@ -57,7 +58,7 @@ public:
     // view config
     t_config(const std::vector<std::string>& row_pivots,
         const std::vector<std::string>& column_pivots, const std::vector<t_aggspec>& aggregates,
-        const std::vector<t_sortspec>& sortspecs, t_filter_op combiner,
+        const std::vector<t_sortspec>& sortspecs, const std::vector<t_sortspec>& col_sortspecs, t_filter_op combiner,
         const std::vector<t_fterm>& fterms, const std::vector<std::string>& col_names,
         bool column_only);
 
@@ -131,6 +132,7 @@ public:
 
     std::vector<std::pair<std::string, std::string>> get_sortby_pairs() const;
     const std::vector<t_sortspec>& get_sortspecs() const;
+    const std::vector<t_sortspec>& get_col_sortspecs() const;
 
     bool has_filters() const;
 
@@ -168,6 +170,7 @@ private:
     bool m_column_only;
     std::map<std::string, std::string> m_sortby;
     std::vector<t_sortspec> m_sortspecs;
+    std::vector<t_sortspec> m_col_sortspecs;
     std::vector<t_aggspec> m_aggregates;
     std::vector<std::string> m_detail_columns;
     t_totals m_totals;

--- a/docs/md/usage.md
+++ b/docs/md/usage.md
@@ -256,7 +256,8 @@ configuration properties for `view()`, see the
 const table = worker.table(data);
 
 const view = table.view({
-    aggregate: [{ column: "Sales", op: "sum" }],
+    columns: ["Sales"],
+    aggregates: {"Sales": "sum"},
     row_pivot: ["Region", "Country"],
     filter: [["Category", "in", ["Furniture", "Technology"]]]
 });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "eslint": "^4.19.1",
         "eslint-config-prettier": "^3.0.1",
         "eslint-plugin-prettier": "^2.6.2",
+        "graceful-fs": "https://github.com/mekwall/node-graceful-fs.git#patch-1",
         "jest": "^24.5.0",
         "js-beautify": "^1.8.6",
         "jsdoc": "^3.5.5",

--- a/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
@@ -41,8 +41,8 @@ function drawChart(chart) {
         if (task.cancelled) {
             return;
         }
-        const row_pivots = config.row_pivot;
-        const col_pivots = config.column_pivot;
+        const row_pivots = config.row_pivots;
+        const col_pivots = config.column_pivots;
         const filter = config.filter;
 
         const filtered = row_pivots.length > 0 ? json.filter(col => col.__ROW_PATH__ && col.__ROW_PATH__.length == row_pivots.length) : json;

--- a/packages/perspective-viewer-highcharts/src/js/config.js
+++ b/packages/perspective-viewer-highcharts/src/js/config.js
@@ -139,7 +139,7 @@ export function default_config(aggregates, mode) {
     const config = this._config;
 
     const axis_titles = get_axis_titles(config.aggregate);
-    const pivot_titles = get_pivot_titles(config.row_pivot, config.column_pivot);
+    const pivot_titles = get_pivot_titles(config.row_pivots, config.column_pivots);
 
     const is_empty = str => str.replace(/\s/g, "") == "";
 
@@ -221,21 +221,21 @@ export function default_config(aggregates, mode) {
                 point: {
                     events: {
                         click: async function() {
-                            let row_pivot_values = [];
+                            let row_pivots_values = [];
                             let column_pivot_values = [];
                             if ((type === "scatter" && mode === "scatter") || (type === "scatter" && mode === "line")) {
                                 column_pivot_values = this.series.userOptions.name.split(", ");
-                                row_pivot_values = this.name.split(", ");
+                                row_pivots_values = this.name.split(", ");
                             } else if (type === "column" || type === "line" || type === "scatter" || type === "area") {
                                 column_pivot_values = this.series.userOptions.name.split(", ");
-                                row_pivot_values = tooltip.get_pivot_values(this.category);
+                                row_pivots_values = tooltip.get_pivot_values(this.category);
                             } else {
                                 console.log(`Click dispatch for ${mode} ${type} not supported.`);
                                 return;
                             }
 
-                            const row_filters = config.row_pivot.map((c, index) => [c, "==", row_pivot_values[index]]);
-                            const column_filters = config.column_pivot.map((c, index) => [c, "==", column_pivot_values[index]]);
+                            const row_filters = config.row_pivots.map((c, index) => [c, "==", row_pivots_values[index]]);
+                            const column_filters = config.column_pivots.map((c, index) => [c, "==", column_pivot_values[index]]);
                             const filters = config.filter
                                 .concat(row_filters)
                                 .concat(column_filters)

--- a/packages/perspective-viewer-highcharts/src/js/draw.js
+++ b/packages/perspective-viewer-highcharts/src/js/draw.js
@@ -46,8 +46,8 @@ export const draw = (mode, set_config) =>
             }
         }
 
-        const row_pivots = this._config.row_pivot;
-        const col_pivots = this._config.column_pivot;
+        const row_pivots = this._config.row_pivots;
+        const col_pivots = this._config.column_pivots;
 
         // FIXME: super tight coupling to private viewer methods
         const aggregates = this._get_view_aggregates();

--- a/packages/perspective-viewer-highcharts/src/js/tooltip.js
+++ b/packages/perspective-viewer-highcharts/src/js/tooltip.js
@@ -8,23 +8,23 @@
  */
 
 export function format_tooltip(context, type, schema, axis_titles, pivot_titles) {
-    const row_pivot_titles = pivot_titles.row,
+    const row_pivots_titles = pivot_titles.row,
         column_pivot_titles = pivot_titles.column;
 
-    const has_row_pivot = row_pivot_titles.length > 0,
-        has_column_pivot = column_pivot_titles.length > 0;
+    const has_row_pivots = row_pivots_titles.length > 0,
+        has_column_pivots = column_pivot_titles.length > 0;
 
     if (type === "y") {
         // pivots cannot be type-mapped
-        let row_pivot_text = "",
+        let row_pivots_text = "",
             column_pivot_text = "";
 
-        if (has_row_pivot) {
-            let row_pivot_values = get_pivot_values(context.key);
-            row_pivot_text = collate_multiple_values(row_pivot_titles, row_pivot_values);
+        if (has_row_pivots) {
+            let row_pivots_values = get_pivot_values(context.key);
+            row_pivots_text = collate_multiple_values(row_pivots_titles, row_pivots_values);
         }
 
-        if (has_column_pivot) {
+        if (has_column_pivots) {
             let column_pivot_values = context.series.userOptions.name.split(", ");
             column_pivot_text = collate_multiple_values(column_pivot_titles, column_pivot_values);
         }
@@ -32,7 +32,7 @@ export function format_tooltip(context, type, schema, axis_titles, pivot_titles)
         const axis_title = context.series.userOptions.stack;
         const axis_type = get_axis_type(axis_title, schema);
 
-        return `${row_pivot_text}
+        return `${row_pivots_text}
                 ${column_pivot_text}
                 <span>${axis_title}: </span><b>${format_value(context.y, axis_type)}</b>`;
     } else if (type === "xy") {
@@ -41,7 +41,7 @@ export function format_tooltip(context, type, schema, axis_titles, pivot_titles)
             has_z_values = value_exists(axis_titles[2]),
             has_w_values = value_exists(axis_titles[3]);
 
-        let row_pivot_text = "",
+        let row_pivots_text = "",
             column_pivot_text = "",
             x_text = "",
             y_text = "",
@@ -49,12 +49,12 @@ export function format_tooltip(context, type, schema, axis_titles, pivot_titles)
             w_text = "";
 
         // render tooltip based on axis + pivots
-        if (has_row_pivot) {
-            let row_pivot_values = context.key.split(",");
-            row_pivot_text = collate_multiple_values(row_pivot_titles, row_pivot_values);
+        if (has_row_pivots) {
+            let row_pivots_values = context.key.split(",");
+            row_pivots_text = collate_multiple_values(row_pivots_titles, row_pivots_values);
         }
 
-        if (has_column_pivot) {
+        if (has_column_pivots) {
             let column_pivot_values = context.point.series.name.split(",");
             column_pivot_text = collate_multiple_values(column_pivot_titles, column_pivot_values);
         }
@@ -84,7 +84,7 @@ export function format_tooltip(context, type, schema, axis_titles, pivot_titles)
             w_text = collate_single_value(w_axis_title, raw_w_axis_value, schema);
         }
 
-        const tooltip_text = [row_pivot_text, column_pivot_text, x_text, y_text, z_text, w_text];
+        const tooltip_text = [row_pivots_text, column_pivot_text, x_text, y_text, z_text, w_text];
         return tooltip_text.join("");
     } else if (type === "xyz") {
         return `<span>${format_value(context.point.value)}</span>`;

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -345,8 +345,8 @@ async function grid_create(div, view, task) {
         return;
     }
 
-    const colPivots = config.column_pivot;
-    const rowPivots = config.row_pivot;
+    const colPivots = config.column_pivots;
+    const rowPivots = config.row_pivots;
     const window = {
         start_row: 0,
         end_row: Math.max(colPivots.length + 1, rowPivots.length + 1)

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -376,6 +376,7 @@ async function grid_create(div, view, task) {
     dataModel.pspFetch = async range => {
         range.end_row += this.hasAttribute("settings") ? 8 : 2;
         range.end_col += rowPivots && rowPivots.length > 0 ? 1 : 0;
+        range.end_col *= hidden.length + 1;
         let next_page = await dataModel._view.to_columns(range);
         dataModel.data = [];
         const rows = psp2hypergrid(next_page, hidden, schema, tschema, rowPivots, columns).rows;

--- a/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
+++ b/packages/perspective-viewer-hypergrid/src/js/perspective-plugin.js
@@ -143,9 +143,9 @@ function sortColumn(event) {
     const column = this.behavior.getColumn(event.detail.column);
     let column_sorting, column_name;
 
-    if (config.column_pivot.length > 0) {
+    if (config.column_pivots.length > 0) {
         column_sorting = true;
-        column_name = column.header.split("|")[config.column_pivot.length]; // index of last column is always the length of the column pivots
+        column_name = column.header.split("|")[config.column_pivots.length]; // index of last column is always the length of the column pivots
     } else {
         column_sorting = false;
         column_name = column.header;
@@ -201,16 +201,16 @@ exports.install = function(grid) {
         event.handled = true;
         const {x, y} = event.dataCell;
         const config = this.dataModel.getConfig();
-        const row_pivots = config.row_pivot;
-        const column_pivots = config.column_pivot;
+        const row_pivots = config.row_pivots;
+        const column_pivots = config.column_pivots;
         const start_row = y >= 0 ? y : 0;
         const end_row = start_row + 1;
         const r = await this.dataModel._view.to_json({start_row, end_row});
         const row_paths = r.map(x => x.__ROW_PATH__);
-        const row_pivot_values = row_paths[0] || [];
+        const row_pivots_values = row_paths[0] || [];
         const row_filters = row_pivots
             .map((pivot, index) => {
-                const pivot_value = row_pivot_values[index];
+                const pivot_value = row_pivots_values[index];
                 return pivot_value ? [pivot, "==", pivot_value] : undefined;
             })
             .filter(x => x);

--- a/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/psp-to-hypergrid.js
@@ -12,10 +12,22 @@ const COLUMN_SEPARATOR_STRING = "|";
 const TREE_COLUMN_INDEX = require("fin-hypergrid/src/behaviors/Behavior").prototype.treeColumnIndex;
 
 function filter_hidden(hidden, json) {
-    for (let key of Object.keys(json)) {
+    let keys;
+    const is_object = !Array.isArray(json);
+    if (is_object) {
+        keys = Object.keys(json);
+    } else {
+        keys = json.map(x => x);
+    }
+    for (let idx in keys) {
+        const key = keys[idx];
         const split_key = key.split(COLUMN_SEPARATOR_STRING);
         if (hidden.indexOf(split_key[split_key.length - 1].trim()) >= 0) {
-            delete json[key];
+            if (is_object) {
+                delete json[key];
+            } else {
+                delete json[idx];
+            }
         }
     }
     return json;
@@ -23,7 +35,7 @@ function filter_hidden(hidden, json) {
 
 function psp2hypergrid(data, hidden, schema, tschema, row_pivots, columns) {
     data = filter_hidden(hidden, data);
-    const colnames = columns || Object.keys(data);
+    const colnames = filter_hidden(hidden, columns || Object.keys(data));
     const firstcol = Object.keys(data).length > 0 ? Object.keys(data)[0] : undefined;
     if (colnames.length === 0 || data[firstcol].length === 0) {
         let columns = Object.keys(schema);

--- a/packages/perspective-viewer-hypergrid/test/js/hypergrid.spec.js
+++ b/packages/perspective-viewer-hypergrid/test/js/hypergrid.spec.js
@@ -21,7 +21,7 @@ const click_details = async page => {
         });
     }, viewer);
 
-    await page.mouse.click(300, 300);
+    await page.mouse.click(310, 300);
     return await click_event;
 };
 
@@ -55,7 +55,7 @@ utils.with_server({}, () => {
                             State: "California",
                             "Sub-Category": "Phones"
                         });
-                        expect(detail.column_names).toEqual(["Order Date"]);
+                        expect(detail.column_names).toEqual(["Ship Date"]);
                         expect(detail.config).toEqual({filters: []});
                     });
                 });

--- a/packages/perspective-viewer-hypergrid/test/results/results.json
+++ b/packages/perspective-viewer-hypergrid/test/results/results.json
@@ -20,13 +20,13 @@
     "superstore.html/resets viewable area when the logical size expands.": "a5d1bad309edf83ceef190dd19d867ec",
     "superstore.html/resets viewable area when the physical size expands.": "59ecbb591317976232b7dc078b79e164",
     "superstore.html/replaces all rows.": "2c41d623f03b2417da7b5dcf7f31e364",
-    "hypergrid.html/perspective dispatches perspective-click event with correct properties.": "f5d6bf82299b2e5f403cdb69b67645fe",
-    "hypergrid.html/perspective dispatches perspective-click event with one filter.": "b7a10ece1d5084742f9a2d88bb68984d",
+    "hypergrid.html/perspective dispatches perspective-click event with correct properties.": "8828c6f1cfd5446a7f4c6c885e4f5fc4",
+    "hypergrid.html/perspective dispatches perspective-click event with one filter.": "e9823ba6e811a853f3791cac57b04dfe",
     "hypergrid.html/perspective dispatches perspective-click event with filters.": "3025f83c828d468207b04d8454e94fda",
     "superstore.html/handles flush": "a5d1bad309edf83ceef190dd19d867ec",
     "superstore.html/should not be able to expand past number of row pivots": "2db398671e7d98f2fa3c7ebabf4a3176",
     "superstore.html/shows a sort indicator": "ad6bb4a58d3c630f45a2ea3e21ee74e1",
     "superstore.html/shows multiple sort indicators": "919e5b8734d8ab684b11649c4b9d6eb4",
     "superstore.html/shows a sort indicator on column split": "79c4434bf30a3517e4537bea8c1ad9bb",
-    "__GIT_COMMIT__": "e44d06594293371bcfef6592e6e7de30b1e562fc"
+    "__GIT_COMMIT__": "972d7cf5a6f8522c571fbb1c114c37866ce58657"
 }

--- a/packages/perspective-viewer/index.d.ts
+++ b/packages/perspective-viewer/index.d.ts
@@ -10,8 +10,8 @@ declare module '@jpmorganchase/perspective-viewer' {
         notifyResize(): void;
 
         schema?: Schema;
-        row_pivot?: Array<string>;
-        column_pivot?: Array<string>;
+        row_pivots?: Array<string>;
+        column_pivots?: Array<string>;
         sort?: Array<string>;
         filter?: Array<Array<string>>;
         aggregate: Array<AggregateConfig>;

--- a/packages/perspective-viewer/src/js/viewer/dom_element.js
+++ b/packages/perspective-viewer/src/js/viewer/dom_element.js
@@ -67,7 +67,7 @@ export class DomElement extends PerspectiveElement {
         if (filter) {
             row.setAttribute("filter", filter);
             if (type === "string") {
-                const v = this._table.view({row_pivot: [name], aggregate: []});
+                const v = this._table.view({row_pivots: [name], aggregate: []});
                 v.to_json().then(json => {
                     row.choices(json.slice(1, json.length).map(x => x.__ROW_PATH__));
                     v.delete();

--- a/packages/perspective-viewer/src/js/viewer/perspective_element.js
+++ b/packages/perspective-viewer/src/js/viewer/perspective_element.js
@@ -219,7 +219,7 @@ export class PerspectiveElement extends StateElement {
             const exclamation = node.shadowRoot.getElementById("row_exclamation");
             const {operator, operand} = JSON.parse(node.getAttribute("filter"));
             const filter = [node.getAttribute("name"), operator, operand];
-            if ((await this._table.is_valid_filter(filter)) && operand !== "") {
+            if ((await this._table.is_valid_philter(filter)) && operand !== "") {
                 filters.push(filter);
                 node.title = "";
                 operandNode.style.borderColor = "";
@@ -261,8 +261,8 @@ export class PerspectiveElement extends StateElement {
         }
         this._view = this._table.view({
             filter: filters,
-            row_pivot: row_pivots,
-            column_pivot: column_pivots,
+            row_pivots: row_pivots,
+            column_pivots: column_pivots,
             aggregate: aggregates,
             sort: sort
         });

--- a/packages/perspective-viewer/src/js/viewer/perspective_element.js
+++ b/packages/perspective-viewer/src/js/viewer/perspective_element.js
@@ -240,18 +240,23 @@ export class PerspectiveElement extends StateElement {
         const row_pivots = this._get_view_row_pivots();
         const column_pivots = this._get_view_column_pivots();
         const filters = await this._validate_filters();
-        const aggregates = this._get_view_aggregates();
-        if (aggregates.length === 0) return;
+        const view_aggregates = this._get_view_aggregates();
+        if (view_aggregates.length === 0) return;
         const sort = this._get_view_sorts();
-        const hidden = this._get_view_hidden(aggregates, sort);
+        const hidden = this._get_view_hidden(view_aggregates, sort);
         for (const s of hidden) {
             const all = this.get_aggregate_attribute();
             if (column_pivots.indexOf(s) > -1 || row_pivots.indexOf(s) > -1) {
-                aggregates.push({column: s, op: "unique"});
+                view_aggregates.push({column: s, op: "unique"});
             } else {
-                aggregates.push(all.reduce((obj, y) => (y.column === s ? y : obj)));
+                view_aggregates.push(all.reduce((obj, y) => (y.column === s ? y : obj)));
             }
         }
+        let columns = view_aggregates.map(x => x.column);
+        let aggregates = view_aggregates.reduce((aggs, a) => {
+            aggs[a.column] = a.op;
+            return aggs;
+        }, {});
 
         if (this._view) {
             this._view.delete();
@@ -263,7 +268,8 @@ export class PerspectiveElement extends StateElement {
             filter: filters,
             row_pivots: row_pivots,
             column_pivots: column_pivots,
-            aggregate: aggregates,
+            aggregates: aggregates,
+            columns: columns,
             sort: sort
         });
 

--- a/packages/perspective-viewer/test/js/utils.js
+++ b/packages/perspective-viewer/test/js/utils.js
@@ -59,7 +59,7 @@ let browser,
 
 beforeAll(async () => {
     browser = await puppeteer.launch({
-        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", '--proxy-server="direct://"', "--proxy-bypass-list=*"]
+        args: ["--disable-accelerated-2d-canvas", "--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", '--proxy-server="direct://"', "--proxy-bypass-list=*"]
     });
     page = await browser.newPage();
 

--- a/packages/perspective/README.md
+++ b/packages/perspective/README.md
@@ -32,7 +32,7 @@ The main API module for Perspective.
         * [.size()](#module_perspective..table+size) ⇒ <code>Promise.&lt;number&gt;</code>
         * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>Promise.&lt;Object&gt;</code>
-        * [.is_valid_filter([filter])](#module_perspective..table+is_valid_filter) ⇒ <code>boolean</code>
+        * [.is_valid_philter([filter])](#module_perspective..table+is_valid_philter) ⇒ <code>boolean</code>
         * [.view([config])](#module_perspective..table+view) ⇒ <code>view</code>
         * [.update(data)](#module_perspective..table+update)
         * [.remove(data)](#module_perspective..table+remove)
@@ -365,7 +365,7 @@ is deleted, this callback will be invoked.
     * [.size()](#module_perspective..table+size) ⇒ <code>Promise.&lt;number&gt;</code>
     * [.schema(computed)](#module_perspective..table+schema) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.computed_schema()](#module_perspective..table+computed_schema) ⇒ <code>Promise.&lt;Object&gt;</code>
-    * [.is_valid_filter([filter])](#module_perspective..table+is_valid_filter) ⇒ <code>boolean</code>
+    * [.is_valid_philter([filter])](#module_perspective..table+is_valid_philter) ⇒ <code>boolean</code>
     * [.view([config])](#module_perspective..table+view) ⇒ <code>view</code>
     * [.update(data)](#module_perspective..table+update)
     * [.remove(data)](#module_perspective..table+remove)
@@ -476,7 +476,7 @@ Object containing the associated column_name, column_type, and computation.
 
 * * *
 
-<a name="module_perspective..table+is_valid_filter"></a>
+<a name="module_perspective..table+is_valid_philter"></a>
 
 #### table.is\_valid\_filter([filter]) ⇒ <code>boolean</code>
 Determines whether a given filter is valid.
@@ -502,9 +502,9 @@ bound to this table
 **Params**
 
 - [config] <code>Object</code> - The configuration object for this [view](#module_perspective..view).
-    - [.row_pivot] <code>Array.&lt;string&gt;</code> - An array of column names
+    - [.row_pivots] <code>Array.&lt;string&gt;</code> - An array of column names
 to use as [Row Pivots](https://en.wikipedia.org/wiki/Pivot_table#Row_labels).
-    - [.column_pivot] <code>Array.&lt;string&gt;</code> - An array of column names
+    - [.column_pivots] <code>Array.&lt;string&gt;</code> - An array of column names
 to use as [Column Pivots](https://en.wikipedia.org/wiki/Pivot_table#Column_labels).
     - [.aggregate] <code>Array.&lt;Object&gt;</code> - An Array of Aggregate configuration objects,
 each of which should provide a "column" and "op" property, representing the string
@@ -520,7 +520,7 @@ which are: "none", "asc", "desc", "col asc", "col desc", "asc abs", "desc abs", 
 **Example**  
 ```js
 var view = table.view({
-     row_pivot: ['region'],
+     row_pivots: ['region'],
      aggregate: [{op: 'dominant', column:'region'}],
      filter: [['client', 'contains', 'fred']],
      sort: [['value', 'asc']]

--- a/packages/perspective/bench/js/browser_runtime.js
+++ b/packages/perspective/bench/js/browser_runtime.js
@@ -23,11 +23,11 @@ const COLUMN_TYPES = {Sales: "number", "Order Date": "datetime", State: "string"
 
 const wait_for_perspective = () => new Promise(resolve => window.addEventListener("perspective-ready", resolve));
 
-function to_name({aggregate, row_pivot, column_pivot}) {
+function to_name({aggregate, row_pivots, column_pivots}) {
     return {
         aggregate: COLUMN_TYPES[aggregate[0].column],
-        row_pivot: row_pivot.join("/") || "-",
-        column_pivot: column_pivot.join("/") || "-"
+        row_pivots: row_pivots.join("/") || "-",
+        column_pivots: column_pivots.join("/") || "-"
     };
 }
 
@@ -68,8 +68,8 @@ async function* run_table_cases(worker, data, test) {
                     test,
                     time: performance.now() - start,
                     method: test,
-                    row_pivot: "n/a",
-                    column_pivot: "n/a",
+                    row_pivots: "n/a",
+                    column_pivots: "n/a",
                     aggregate: "n/a"
                 };
             }
@@ -169,9 +169,9 @@ async function* run_all_delta_cases() {
     await table.schema();
 
     const aggregate = AGG_OPTIONS[0];
-    for (const row_pivot of ROW_PIVOT_OPTIONS) {
-        for (const column_pivot of COLUMN_PIVOT_OPTIONS) {
-            const config = {aggregate, row_pivot, column_pivot};
+    for (const row_pivots of ROW_PIVOT_OPTIONS) {
+        for (const column_pivots of COLUMN_PIVOT_OPTIONS) {
+            const config = {aggregate, row_pivots, column_pivots};
 
             yield* run_on_update_cases(table, config, "none");
             yield* run_on_update_cases(table, config, "rows");
@@ -195,9 +195,9 @@ async function* run_all_cases() {
     await table.schema();
 
     for (const aggregate of AGG_OPTIONS) {
-        for (const row_pivot of ROW_PIVOT_OPTIONS) {
-            for (const column_pivot of COLUMN_PIVOT_OPTIONS) {
-                const config = {aggregate, row_pivot, column_pivot};
+        for (const row_pivots of ROW_PIVOT_OPTIONS) {
+            for (const column_pivots of COLUMN_PIVOT_OPTIONS) {
+                const config = {aggregate, row_pivots, column_pivots};
 
                 yield* run_view_cases(table, config);
                 yield* run_to_format_cases(table, config, "to_json");

--- a/packages/perspective/index.d.ts
+++ b/packages/perspective/index.d.ts
@@ -108,8 +108,8 @@ declare module '@jpmorganchase/perspective' {
     };
 
     export type ViewConfig = {
-        row_pivot?: Array<string>;
-        column_pivot?: Array<string>;
+        row_pivots?: Array<string>;
+        column_pivots?: Array<string>;
         sort?: Array<string>;
         filter?: Array<Array<string>>;
         aggregate: Array<AggregateConfig>;

--- a/packages/perspective/src/js/api.js
+++ b/packages/perspective/src/js/api.js
@@ -179,7 +179,7 @@ table.prototype.column_metadata = async_queue("column_metadata", "table_method")
 
 table.prototype.computed_schema = async_queue("computed_schema", "table_method");
 
-table.prototype.is_valid_filter = async_queue("is_valid_filter", "table_method");
+table.prototype.is_valid_philter = async_queue("is_valid_philter", "table_method");
 
 table.prototype.size = async_queue("size", "table_method");
 

--- a/packages/perspective/src/js/defaults.js
+++ b/packages/perspective/src/js/defaults.js
@@ -7,6 +7,22 @@
  *
  */
 
+export const CONFIG_ALIASES = {
+    row_pivot: "row_pivots",
+    "row-pivot": "row_pivots",
+    "row-pivots": "row_pivots",
+    col_pivot: "column_pivots",
+    col_pivots: "column_pivots",
+    column_pivot: "column_pivots",
+    "column-pivot": "column_pivots",
+    "column-pivots": "column_pivots",
+    filters: "filter",
+    sorts: "sort",
+    aggregates: "aggregate"
+};
+
+export const CONFIG_VALID_KEYS = ["viewport", "row_pivots", "column_pivots", "aggregate", "filter", "sort", "row_pivot_depth", "filter_op"];
+
 const NUMBER_AGGREGATES = [
     "any",
     "avg",

--- a/packages/perspective/src/js/defaults.js
+++ b/packages/perspective/src/js/defaults.js
@@ -17,11 +17,10 @@ export const CONFIG_ALIASES = {
     "column-pivot": "column_pivots",
     "column-pivots": "column_pivots",
     filters: "filter",
-    sorts: "sort",
-    aggregates: "aggregate"
+    sorts: "sort"
 };
 
-export const CONFIG_VALID_KEYS = ["viewport", "row_pivots", "column_pivots", "aggregate", "filter", "sort", "row_pivot_depth", "filter_op"];
+export const CONFIG_VALID_KEYS = ["viewport", "row_pivots", "column_pivots", "aggregates", "columns", "filter", "sort", "row_pivot_depth", "filter_op"];
 
 const NUMBER_AGGREGATES = [
     "any",

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -922,14 +922,14 @@ export default function(Module) {
     table.prototype.view = function(_config = {}) {
         let config = {};
         for (const key of Object.keys(_config)) {
-            if (CONFIG_ALIASES[key]) {
-                if (!config[CONFIG_ALIASES[key]]) {
-                    console.warn(`Deprecated: "${key}" config parameter, please use "${CONFIG_ALIASES[key]}" instead`);
-                    config[CONFIG_ALIASES[key]] = _config[key];
+            if (defaults.CONFIG_ALIASES[key]) {
+                if (!config[defaults.CONFIG_ALIASES[key]]) {
+                    console.warn(`Deprecated: "${key}" config parameter, please use "${defaults.CONFIG_ALIASES[key]}" instead`);
+                    config[defaults.CONFIG_ALIASES[key]] = _config[key];
                 } else {
                     throw new Error(`Duplicate configuration parameter "${key}"`);
                 }
-            } else if (CONFIG_VALID_KEYS.indexOf(key) > -1) {
+            } else if (defaults.CONFIG_VALID_KEYS.indexOf(key) > -1) {
                 config[key] = _config[key];
             } else {
                 throw new Error(`Unrecognized config parameter "${key}"`);

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -473,7 +473,7 @@ export default function(Module) {
             // columns start at 1 for > 0-sided views
             return __MODULE__.col_to_js_typed_array_one(this._View, idx + 1, false, start_row, end_row);
         } else {
-            const column_pivot_only = this.config.row_pivot[0] === "psp_okey" || this.column_only === true;
+            const column_pivot_only = this.config.row_pivots[0] === "psp_okey" || this.column_only === true;
             return __MODULE__.col_to_js_typed_array_two(this._View, idx + 1, column_pivot_only, start_row, end_row);
         }
     };
@@ -546,7 +546,7 @@ export default function(Module) {
 
     /**
      * The number of aggregated columns in this {@link view}.  This is affected by
-     * the "column_pivot" configuration parameter supplied to this {@link view}'s
+     * the "column_pivots" configuration parameter supplied to this {@link view}'s
      * contructor.
      *
      * @async
@@ -576,7 +576,7 @@ export default function(Module) {
      * @returns {Promise<void>}
      */
     view.prototype.expand = async function(idx) {
-        return this._View.expand(idx, this.config.row_pivot.length);
+        return this._View.expand(idx, this.config.row_pivots.length);
     };
 
     /**
@@ -595,7 +595,7 @@ export default function(Module) {
      *
      */
     view.prototype.set_depth = async function(depth) {
-        return this._View.set_depth(depth, this.config.row_pivot.length);
+        return this._View.set_depth(depth, this.config.row_pivots.length);
     };
 
     /**
@@ -869,7 +869,7 @@ export default function(Module) {
         return key => schema[key] === "datetime" || schema[key] === "date";
     };
 
-    table.prototype._is_valid_filter = function(filter) {
+    table.prototype._is_valid_philter = function(filter) {
         const schema = this._schema();
         const isDateFilter = this._is_date_filter(schema);
         const value = isDateFilter(filter[0]) ? new DateParser().parse(filter[2]) : filter[2];
@@ -883,8 +883,8 @@ export default function(Module) {
      *
      * @returns {boolean} Whether the filter is valid
      */
-    table.prototype.is_valid_filter = function(filter) {
-        return this._is_valid_filter(filter);
+    table.prototype.is_valid_philter = function(filter) {
+        return this._is_valid_philter(filter);
     };
 
     /**
@@ -892,9 +892,9 @@ export default function(Module) {
      * configuration.
      *
      * @param {Object} [config] The configuration object for this {@link module:perspective~view}.
-     * @param {Array<string>} [config.row_pivot] An array of column names
+     * @param {Array<string>} [config.row_pivots] An array of column names
      * to use as {@link https://en.wikipedia.org/wiki/Pivot_table#Row_labels Row Pivots}.
-     * @param {Array<string>} [config.column_pivot] An array of column names
+     * @param {Array<string>} [config.column_pivots] An array of column names
      * to use as {@link https://en.wikipedia.org/wiki/Pivot_table#Column_labels Column Pivots}.
      * @param {Array<Object>} [config.aggregate] An Array of Aggregate configuration objects,
      * each of which should provide a "column" and "op" property, representing the string
@@ -909,7 +909,7 @@ export default function(Module) {
      *
      * @example
      * var view = table.view({
-     *      row_pivot: ['region'],
+     *      row_pivots: ['region'],
      *      aggregate: [{op: 'dominant', column:'region'}],
      *      filter: [['client', 'contains', 'fred']],
      *      sort: [['value', 'asc']]
@@ -923,14 +923,14 @@ export default function(Module) {
 
         let name = Math.random() + "";
 
-        config.row_pivot = config.row_pivot || [];
-        config.column_pivot = config.column_pivot || [];
+        config.row_pivots = config.row_pivots || [];
+        config.column_pivots = config.column_pivots || [];
         config.filter = config.filter || [];
 
         let sides;
 
-        if (config.row_pivot.length > 0 || config.column_pivot.length > 0) {
-            if (config.column_pivot && config.column_pivot.length > 0) {
+        if (config.row_pivots.length > 0 || config.column_pivots.length > 0) {
+            if (config.column_pivots && config.column_pivots.length > 0) {
                 sides = 2;
             } else {
                 sides = 1;

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -919,8 +919,22 @@ export default function(Module) {
      * @returns {view} A new {@link module:perspective~view} object for the supplied configuration,
      * bound to this table
      */
-    table.prototype.view = function(config) {
-        config = {...config};
+    table.prototype.view = function(_config = {}) {
+        let config = {};
+        for (const key of Object.keys(_config)) {
+            if (CONFIG_ALIASES[key]) {
+                if (!config[CONFIG_ALIASES[key]]) {
+                    console.warn(`Deprecated: "${key}" config parameter, please use "${CONFIG_ALIASES[key]}" instead`);
+                    config[CONFIG_ALIASES[key]] = _config[key];
+                } else {
+                    throw new Error(`Duplicate configuration parameter "${key}"`);
+                }
+            } else if (CONFIG_VALID_KEYS.indexOf(key) > -1) {
+                config[key] = _config[key];
+            } else {
+                throw new Error(`Unrecognized config parameter "${key}"`);
+            }
+        }
 
         let name = Math.random() + "";
 

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -457,10 +457,12 @@ export default function(Module) {
     view.prototype.col_to_js_typed_array = async function(col_name, options = {}) {
         const names = await this._column_names();
         const num_rows = await this.num_rows();
+        const column_pivot_only = this.config.row_pivots[0] === "psp_okey" || this.column_only === true;
+
         let idx = names.indexOf(col_name);
 
         const start_row = options.start_row || 0;
-        const end_row = options.end_row || num_rows;
+        const end_row = (options.end_row || num_rows) + (column_pivot_only ? 1 : 0);
 
         // type-checking is handled in c++ to accomodate column-pivoted views
         if (idx === -1) {
@@ -473,7 +475,6 @@ export default function(Module) {
             // columns start at 1 for > 0-sided views
             return __MODULE__.col_to_js_typed_array_one(this._View, idx + 1, false, start_row, end_row);
         } else {
-            const column_pivot_only = this.config.row_pivots[0] === "psp_okey" || this.column_only === true;
             return __MODULE__.col_to_js_typed_array_two(this._View, idx + 1, column_pivot_only, start_row, end_row);
         }
     };

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -255,7 +255,7 @@ module.exports = perspective => {
         it("Int, 1-sided view", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view({
-                row_pivot: ["int"],
+                row_pivots: ["int"],
                 aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
             });
             const result = await view.col_to_js_typed_array("int");
@@ -268,7 +268,7 @@ module.exports = perspective => {
         it("Float, 1-sided view", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view({
-                row_pivot: ["int"],
+                row_pivots: ["int"],
                 aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
             });
             const result = await view.col_to_js_typed_array("float");
@@ -280,7 +280,7 @@ module.exports = perspective => {
         it("Datetime, 1-sided view", async function() {
             var table = perspective.table(datetime_data);
             var view = table.view({
-                row_pivot: ["int"],
+                row_pivots: ["int"],
                 aggregate: [{op: "high", column: "datetime"}]
             });
             const result = await view.col_to_js_typed_array("datetime");
@@ -292,8 +292,8 @@ module.exports = perspective => {
         it("Int, 2-sided view with row pivot", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view({
-                column_pivot: ["float"],
-                row_pivot: ["int"],
+                column_pivots: ["float"],
+                row_pivots: ["int"],
                 aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
             });
             const result = await view.col_to_js_typed_array("3.5|int");
@@ -305,8 +305,8 @@ module.exports = perspective => {
         it("Float, 2-sided view with row pivot", async function() {
             var table = perspective.table(int_float_data);
             var view = table.view({
-                column_pivot: ["float"],
-                row_pivot: ["int"],
+                column_pivots: ["float"],
+                row_pivots: ["int"],
                 aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
             });
             const result = await view.col_to_js_typed_array("3.5|float");
@@ -317,7 +317,7 @@ module.exports = perspective => {
 
         it("Int, 2-sided view, no row pivot", async function() {
             var table = perspective.table(int_float_data);
-            var view = table.view({column_pivot: ["float"]});
+            var view = table.view({column_pivots: ["float"]});
             const result = await view.col_to_js_typed_array("3.5|int");
             // bytelength should not include the aggregate row
             expect(result[0].byteLength).toEqual(12);
@@ -327,7 +327,7 @@ module.exports = perspective => {
 
         it("Float, 2-sided view, no row pivot", async function() {
             var table = perspective.table(int_float_data);
-            var view = table.view({column_pivot: ["float"]});
+            var view = table.view({column_pivots: ["float"]});
             const result = await view.col_to_js_typed_array("3.5|float");
             expect(result[0].byteLength).toEqual(24);
             view.delete();
@@ -354,7 +354,7 @@ module.exports = perspective => {
         it("Symmetric output with to_columns, 1-sided", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                row_pivot: ["int"],
+                row_pivots: ["int"],
                 aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
             });
             let cols = await view.to_columns();
@@ -386,7 +386,7 @@ module.exports = perspective => {
         it("Serializes 1 sided view to CSV", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "sum", column: "x"}]
             });
             var answer = `__ROW_PATH__,x\r\n,10\r\nfalse,6\r\ntrue,4`;
@@ -399,8 +399,8 @@ module.exports = perspective => {
         it("Serializes a 2 sided view to CSV", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
-                column_pivot: ["y"],
+                row_pivots: ["z"],
+                column_pivots: ["y"],
                 aggregate: [{op: "sum", column: "x"}]
             });
             var answer = `__ROW_PATH__,\"a,x\",\"b,x\",\"c,x\",\"d,x\"\r\n,1,2,3,4\r\nfalse,,2,,4\r\ntrue,1,,3,`;
@@ -528,7 +528,7 @@ module.exports = perspective => {
             var view = table.view();
             var num_rows = await view.num_rows();
             var view2 = table.view({
-                column_pivot: ["x"]
+                column_pivots: ["x"]
             });
             var num_rows_col_only = await view2.num_rows();
             expect(num_rows_col_only).toEqual(num_rows);

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -320,7 +320,7 @@ module.exports = perspective => {
             var view = table.view({column_pivots: ["float"]});
             const result = await view.col_to_js_typed_array("3.5|int");
             // bytelength should not include the aggregate row
-            expect(result[0].byteLength).toEqual(12);
+            expect(result[0].byteLength).toEqual(16);
             view.delete();
             table.delete();
         });
@@ -329,7 +329,7 @@ module.exports = perspective => {
             var table = perspective.table(int_float_data);
             var view = table.view({column_pivots: ["float"]});
             const result = await view.col_to_js_typed_array("3.5|float");
-            expect(result[0].byteLength).toEqual(24);
+            expect(result[0].byteLength).toEqual(32);
             view.delete();
             table.delete();
         });

--- a/packages/perspective/test/js/constructors.js
+++ b/packages/perspective/test/js/constructors.js
@@ -212,9 +212,9 @@ module.exports = perspective => {
             table.delete();
         });
 
-        it("0-sided view with aggregate selection", async function() {
+        it("0-sided view with columns selection", async function() {
             const table = perspective.table(int_float_string_data);
-            const view = table.view({aggregate: [{column: "float", op: "sum"}, {column: "string", op: "sum"}]});
+            const view = table.view({columns: ["float", "string"]});
             const schema = await view.schema();
             expect(schema).toEqual({float: "float", string: "string"});
             view.delete();
@@ -256,7 +256,7 @@ module.exports = perspective => {
             var table = perspective.table(int_float_data);
             var view = table.view({
                 row_pivots: ["int"],
-                aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
+                columns: ["int", "float"]
             });
             const result = await view.col_to_js_typed_array("int");
             // should include aggregate row
@@ -269,7 +269,7 @@ module.exports = perspective => {
             var table = perspective.table(int_float_data);
             var view = table.view({
                 row_pivots: ["int"],
-                aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
+                columns: ["int", "float"]
             });
             const result = await view.col_to_js_typed_array("float");
             expect(result[0].byteLength).toEqual(40);
@@ -281,7 +281,8 @@ module.exports = perspective => {
             var table = perspective.table(datetime_data);
             var view = table.view({
                 row_pivots: ["int"],
-                aggregate: [{op: "high", column: "datetime"}]
+                columns: ["datetime"],
+                aggregates: {datetime: "high"}
             });
             const result = await view.col_to_js_typed_array("datetime");
             expect(result[0].byteLength).toEqual(24);
@@ -294,7 +295,7 @@ module.exports = perspective => {
             var view = table.view({
                 column_pivots: ["float"],
                 row_pivots: ["int"],
-                aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
+                columns: ["int", "float"]
             });
             const result = await view.col_to_js_typed_array("3.5|int");
             expect(result[0].byteLength).toEqual(20);
@@ -307,7 +308,7 @@ module.exports = perspective => {
             var view = table.view({
                 column_pivots: ["float"],
                 row_pivots: ["int"],
-                aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
+                columns: ["int", "float"]
             });
             const result = await view.col_to_js_typed_array("3.5|float");
             expect(result[0].byteLength).toEqual(40);
@@ -355,7 +356,7 @@ module.exports = perspective => {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
                 row_pivots: ["int"],
-                aggregate: [{op: "sum", column: "int"}, {op: "sum", column: "float"}]
+                columns: ["int", "float"]
             });
             let cols = await view.to_columns();
 
@@ -387,7 +388,7 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["z"],
-                aggregate: [{op: "sum", column: "x"}]
+                columns: ["x"]
             });
             var answer = `__ROW_PATH__,x\r\n,10\r\nfalse,6\r\ntrue,4`;
             let result = await view.to_csv();
@@ -401,7 +402,7 @@ module.exports = perspective => {
             var view = table.view({
                 row_pivots: ["z"],
                 column_pivots: ["y"],
-                aggregate: [{op: "sum", column: "x"}]
+                columns: ["x"]
             });
             var answer = `__ROW_PATH__,\"a,x\",\"b,x\",\"c,x\",\"d,x\"\r\n,1,2,3,4\r\nfalse,,2,,4\r\ntrue,1,,3,`;
             let result = await view.to_csv();
@@ -804,7 +805,7 @@ module.exports = perspective => {
                         inputs: []
                     }
                 ]);
-                let view = table2.view({aggregate: [{op: "count", column: "const"}]});
+                let view = table2.view({columns: ["const"], aggregates: {const: "count"}});
                 let result = await view.to_json();
                 expect(result).toEqual([{const: 1}, {const: 1}, {const: 1}, {const: 1}]);
                 view.delete();
@@ -823,7 +824,7 @@ module.exports = perspective => {
                         inputs: ["w", "x"]
                     }
                 ]);
-                let view = table2.view({aggregate: [{op: "count", column: "ratio"}]});
+                let view = table2.view({columns: ["ratio"], aggregates: {ratio: "count"}});
                 let result = await view.to_json();
                 expect(result).toEqual([{ratio: 1.5}, {ratio: 1.25}, {ratio: 1.1666666666666667}, {ratio: 1.125}]);
                 view.delete();
@@ -852,7 +853,7 @@ module.exports = perspective => {
 
                 let delta_upd = [{y: "a", z: false}, {y: "b", z: true}, {y: "c", z: false}, {y: "d", z: true}];
                 table2.update(delta_upd);
-                let view = table2.view({aggregate: [{op: "count", column: "y"}, {op: "count", column: "ratio"}]});
+                let view = table2.view({columns: ["y", "ratio"], aggregates: {y: "count", ratio: "count"}});
                 let result = await view.to_json();
                 let expected = [{y: "a", ratio: 1.5}, {y: "b", ratio: 1.25}, {y: "c", ratio: 1.1666666666666667}, {y: "d", ratio: 1.125}];
                 expect(result).toEqual(expected);
@@ -872,7 +873,7 @@ module.exports = perspective => {
                         inputs: ["z"]
                     }
                 ]);
-                let view = table2.view({aggregate: [{op: "count", column: "yes/no"}]});
+                let view = table2.view({columns: ["yes/no"], aggregates: {"yes/no": "count"}});
                 let result = await view.to_json();
                 let expected = [{"yes/no": "yes"}, {"yes/no": "no"}, {"yes/no": "yes"}, {"yes/no": "no"}];
                 expect(result).toEqual(expected);

--- a/packages/perspective/test/js/delta.js
+++ b/packages/perspective/test/js/delta.js
@@ -101,7 +101,7 @@ module.exports = perspective => {
             it("returns changed rows", async function(done) {
                 let table = perspective.table(data, {index: "x"});
                 let view = table.view({
-                    row_pivot: ["y"]
+                    row_pivots: ["y"]
                 });
                 view.on_update(
                     async function(delta) {
@@ -118,7 +118,7 @@ module.exports = perspective => {
             it("returns nothing when updated data is not in pivot", async function(done) {
                 let table = perspective.table(data, {index: "x"});
                 let view = table.view({
-                    row_pivot: ["y"]
+                    row_pivots: ["y"]
                 });
                 view.on_update(
                     async function(delta) {
@@ -137,8 +137,8 @@ module.exports = perspective => {
             it("returns changed rows when updated data in row pivot", async function(done) {
                 let table = perspective.table(data, {index: "y"});
                 let view = table.view({
-                    row_pivot: ["y"],
-                    column_pivot: ["x"]
+                    row_pivots: ["y"],
+                    column_pivots: ["x"]
                 });
                 view.on_update(
                     async function(delta) {
@@ -155,8 +155,8 @@ module.exports = perspective => {
             it("returns changed rows when updated data in column pivot", async function(done) {
                 let table = perspective.table(data, {index: "x"});
                 let view = table.view({
-                    row_pivot: ["y"],
-                    column_pivot: ["z"]
+                    row_pivots: ["y"],
+                    column_pivots: ["z"]
                 });
                 view.on_update(
                     async function(delta) {
@@ -173,8 +173,8 @@ module.exports = perspective => {
             it("returns changed rows when updated data in row and column pivot", async function(done) {
                 let table = perspective.table(data, {index: "x"});
                 let view = table.view({
-                    row_pivot: ["y"],
-                    column_pivot: ["z"]
+                    row_pivots: ["y"],
+                    column_pivots: ["z"]
                 });
                 view.on_update(
                     async function(delta) {
@@ -191,8 +191,8 @@ module.exports = perspective => {
             it("returns nothing when updated data is not in pivot", async function(done) {
                 let table = perspective.table(data, {index: "x"});
                 let view = table.view({
-                    row_pivot: ["y"],
-                    column_pivot: ["x"]
+                    row_pivots: ["y"],
+                    column_pivots: ["x"]
                 });
                 view.on_update(
                     async function(delta) {

--- a/packages/perspective/test/js/filters.js
+++ b/packages/perspective/test/js/filters.js
@@ -356,28 +356,28 @@ module.exports = perspective => {
             });
         });
 
-        describe("is_valid_filter", function() {
+        describe("is_valid_philter", function() {
             it("x == 2", async function() {
                 var table = perspective.table(data);
-                let isValid = await table.is_valid_filter(["x", "==", 2]);
+                let isValid = await table.is_valid_philter(["x", "==", 2]);
                 expect(isValid).toBeTruthy();
                 table.delete();
             });
             it("x < null", async function() {
                 var table = perspective.table(data);
-                let isValid = await table.is_valid_filter(["x", "<", null]);
+                let isValid = await table.is_valid_philter(["x", "<", null]);
                 expect(isValid).toBeFalsy();
                 table.delete();
             });
             it("x > undefined", async function() {
                 var table = perspective.table(data);
-                let isValid = await table.is_valid_filter(["x", ">", undefined]);
+                let isValid = await table.is_valid_philter(["x", ">", undefined]);
                 expect(isValid).toBeFalsy();
                 table.delete();
             });
             it('x == ""', async function() {
                 var table = perspective.table(data);
-                let isValid = await table.is_valid_filter(["x", "==", ""]);
+                let isValid = await table.is_valid_philter(["x", "==", ""]);
                 expect(isValid).toBeTruthy();
                 table.delete();
             });
@@ -387,7 +387,7 @@ module.exports = perspective => {
                     y: "date"
                 };
                 var table = perspective.table(schema);
-                let isValid = await table.is_valid_filter(["y", "==", "01-01-1970"]);
+                let isValid = await table.is_valid_philter(["y", "==", "01-01-1970"]);
                 expect(isValid).toBeTruthy();
                 table.delete();
             });
@@ -397,7 +397,7 @@ module.exports = perspective => {
                     y: "date"
                 };
                 var table = perspective.table(schema);
-                let isValid = await table.is_valid_filter(["y", "<", "1234"]);
+                let isValid = await table.is_valid_philter(["y", "<", "1234"]);
                 expect(isValid).toBeFalsy();
                 table.delete();
             });
@@ -407,7 +407,7 @@ module.exports = perspective => {
                     y: "datetime"
                 };
                 var table = perspective.table(schema);
-                let isValid = await table.is_valid_filter(["y", "==", "11:11:11.111"]);
+                let isValid = await table.is_valid_philter(["y", "==", "11:11:11.111"]);
                 expect(isValid).toBeTruthy();
                 table.delete();
             });
@@ -417,7 +417,7 @@ module.exports = perspective => {
                     y: "datetime"
                 };
                 var table = perspective.table(schema);
-                let isValid = await table.is_valid_filter(["y", ">", "11:11:11:111"]);
+                let isValid = await table.is_valid_philter(["y", ">", "11:11:11:111"]);
                 expect(isValid).toBeFalsy();
                 table.delete();
             });

--- a/packages/perspective/test/js/internal.js
+++ b/packages/perspective/test/js/internal.js
@@ -25,7 +25,7 @@ module.exports = (perspective, mode) => {
             var table = perspective.table(arrow.slice());
             let anon = function() {
                 table.view({
-                    row_pivot: ["char"],
+                    row_pivots: ["char"],
                     aggregate: [{op: "sum", column: ["f16", "f32"]}]
                 });
             };

--- a/packages/perspective/test/js/internal.js
+++ b/packages/perspective/test/js/internal.js
@@ -20,19 +20,6 @@ module.exports = (perspective, mode) => {
             expect(perspective.__module__.wasmJSMethod).toEqual(mode === "ASMJS" ? "asmjs" : "native-wasm");
         });
 
-        // FIXME: throw no longer occurs in agg construction
-        it.skip("['z'], sum with new column syntax with wrong column arity errors", async function() {
-            var table = perspective.table(arrow.slice());
-            let anon = function() {
-                table.view({
-                    row_pivots: ["char"],
-                    aggregate: [{op: "sum", column: ["f16", "f32"]}]
-                });
-            };
-            expect(anon).toThrow();
-            table.delete();
-        });
-
         it("Arrow schema types are mapped correctly", async function() {
             // This only works for non parallel
             var table = perspective.table(arrow.slice());

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -30,7 +30,7 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["z"],
-                aggregate: [{op: "sum", column: "x"}]
+                columns: ["x"]
             });
             var answer = [{__ROW_PATH__: [], x: 10}, {__ROW_PATH__: [false], x: 6}, {__ROW_PATH__: [true], x: 4}];
             let result = await view.to_json();
@@ -43,7 +43,7 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["z"],
-                aggregate: [{op: "sum", column: ["x"]}]
+                columns: ["x"]
             });
             var answer = [{__ROW_PATH__: [], x: 10}, {__ROW_PATH__: [false], x: 6}, {__ROW_PATH__: [true], x: 4}];
             let result = await view.to_json();
@@ -69,7 +69,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["z"],
-                aggregate: [{op: "mean", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "mean"}
             });
             var answer = [{__ROW_PATH__: [], x: 2.5}, {__ROW_PATH__: [false], x: 3}, {__ROW_PATH__: [true], x: 2}];
             let result = await view.to_json();
@@ -82,7 +83,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["z"],
-                aggregate: [{op: "first by index", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "first by index"}
             });
             var answer = [{__ROW_PATH__: [], x: 1}, {__ROW_PATH__: [false], x: 2}, {__ROW_PATH__: [true], x: 1}];
             let result = await view.to_json();
@@ -95,7 +97,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["z"],
-                aggregate: [{op: "last by index", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "last by index"}
             });
             var answer = [{__ROW_PATH__: [], x: 4}, {__ROW_PATH__: [false], x: 4}, {__ROW_PATH__: [true], x: 3}];
             let result = await view.to_json();
@@ -108,7 +111,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["z"],
-                aggregate: [{op: "last", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "last"}
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [false], x: 4}, {__ROW_PATH__: [true], x: 3}];
             let result = await view.to_json();
@@ -128,7 +132,8 @@ module.exports = perspective => {
             var table = perspective.table([{x: 3, y: 1}, {x: 2, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
                 row_pivots: ["y"],
-                aggregate: [{op: "mean", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "mean"}
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [1], x: 2.5}, {__ROW_PATH__: [2], x: 4}];
             let result = await view.to_json();
@@ -141,7 +146,8 @@ module.exports = perspective => {
             var table = perspective.table([{x: 3, y: 1}, {x: 3, y: 1}, {x: 0, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
                 row_pivots: ["y"],
-                aggregate: [{op: "mean", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "mean"}
             });
             var answer = [{__ROW_PATH__: [], x: 2.5}, {__ROW_PATH__: [1], x: 2}, {__ROW_PATH__: [2], x: 4}];
             let result = await view.to_json();
@@ -155,7 +161,8 @@ module.exports = perspective => {
             table.update([{x: 3, y: 1}, {x: 3, y: 1}, {x: 0, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
                 row_pivots: ["y"],
-                aggregate: [{op: "mean", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "mean"}
             });
             var answer = [{__ROW_PATH__: [], x: 2.5}, {__ROW_PATH__: [1], x: 2}, {__ROW_PATH__: [2], x: 4}];
             let result = await view.to_json();
@@ -168,7 +175,7 @@ module.exports = perspective => {
             var table = perspective.table([{x: 3, y: 1}, {x: 2, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
                 row_pivots: ["y"],
-                aggregate: [{op: "sum", column: "x"}]
+                columns: ["x"]
             });
             var answer = [{__ROW_PATH__: [], x: 9}, {__ROW_PATH__: [1], x: 5}, {__ROW_PATH__: [2], x: 4}];
             let result = await view.to_json();
@@ -182,7 +189,8 @@ module.exports = perspective => {
             table.update([{x: 2, y: 1}, {x: null, y: 1}, {x: 4, y: 2}]);
             var view = table.view({
                 row_pivots: ["y"],
-                aggregate: [{op: "mean", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "mean"}
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [1], x: 2.5}, {__ROW_PATH__: [2], x: 4}];
             let result = await view.to_json();
@@ -197,7 +205,8 @@ module.exports = perspective => {
             table.update([{x: 2, y: 2, z: "c"}, {x: 3, y: 2, z: "c"}, {x: null, y: 2, z: "c"}, {x: 7, y: 2, z: "c"}]);
             var view = table.view({
                 row_pivots: ["y", "z"],
-                aggregate: [{op: "mean", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "mean"}
             });
             var answer = [
                 {__ROW_PATH__: [], x: 3.142857142857143},
@@ -219,7 +228,8 @@ module.exports = perspective => {
             var table = perspective.table([{x: null}, {x: "x"}, {x: "y"}]);
             var view = table.view({
                 row_pivots: ["x"],
-                aggregate: [{op: "distinct count", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "distinct count"}
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [null], x: 1}, {__ROW_PATH__: ["x"], x: 1}, {__ROW_PATH__: ["y"], x: 1}];
             let result = await view.to_json();
@@ -247,7 +257,8 @@ module.exports = perspective => {
             var table = perspective.table([{x: 3, y: 1}, {x: 2, y: 1}, {x: 1, y: 1}, {x: -1, y: 1}, {x: -2, y: 2}, {x: -3, y: 2}]);
             var view = table.view({
                 row_pivots: ["y"],
-                aggregate: [{op: "sum abs", column: "x"}]
+                columns: ["x"],
+                aggregates: {x: "sum abs"}
             });
             var answer = [{__ROW_PATH__: [], x: 12}, {__ROW_PATH__: [1], x: 7}, {__ROW_PATH__: [2], x: 5}];
             let result = await view.to_json();
@@ -288,7 +299,7 @@ module.exports = perspective => {
             table.update(rec1);
             let view = table.view({
                 row_pivots: ["id"],
-                aggregate: [{op: "sum", column: "pos"}]
+                columns: ["pos"]
             });
             let rec2 = [{id: 1, chg: 3}];
             table.update(rec2);
@@ -362,7 +373,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["x"],
-                aggregate: [{column: "y", op: "distinct count"}]
+                columns: ["y"],
+                aggregates: {y: "distinct count"}
             });
             let result2 = await view.schema();
             expect(result2).toEqual({y: "integer"});
@@ -374,7 +386,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 row_pivots: ["y"],
-                aggregate: [{column: "x", op: "avg"}]
+                columns: ["x"],
+                aggregates: {x: "avg"}
             });
             let result2 = await view.schema();
             expect(result2).toEqual({x: "float"});
@@ -386,7 +399,8 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 column_pivots: ["y"],
-                aggregate: [{column: "x", op: "avg"}]
+                columns: ["x"],
+                aggregates: {x: "avg"}
             });
             let result2 = await view.schema();
             expect(result2).toEqual({x: "integer"});
@@ -596,7 +610,7 @@ module.exports = perspective => {
             var table = perspective.table(data);
             var view = table.view({
                 column_pivots: ["x", "z"],
-                aggregate: [{column: "y", op: "sum"}]
+                columns: ["y"]
             });
             let result2 = await view.to_json();
             expect(result2).toEqual([
@@ -629,7 +643,8 @@ module.exports = perspective => {
             var view = table.view({
                 column_pivots: ["z", "b"],
                 row_pivots: ["y", "a"],
-                aggregate: [{column: "x", op: "last"}]
+                columns: ["x"],
+                aggregates: {x: "last"}
             });
 
             let answer = [
@@ -701,7 +716,8 @@ module.exports = perspective => {
                 column_pivots: ["y"],
                 row_pivots: ["z"],
                 sort: [["y", "col desc"]],
-                aggregate: [{column: "x", op: "sum"}, {column: "y", op: "any"}]
+                columns: ["x", "y"],
+                aggregates: {x: "sum", y: "any"}
             });
 
             let result2 = await view.to_columns();

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -29,7 +29,7 @@ module.exports = perspective => {
         it("['z'], sum", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "sum", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 10}, {__ROW_PATH__: [false], x: 6}, {__ROW_PATH__: [true], x: 4}];
@@ -42,7 +42,7 @@ module.exports = perspective => {
         it("['z'], sum with new column syntax", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "sum", column: ["x"]}]
             });
             var answer = [{__ROW_PATH__: [], x: 10}, {__ROW_PATH__: [false], x: 6}, {__ROW_PATH__: [true], x: 4}];
@@ -55,7 +55,7 @@ module.exports = perspective => {
         it("['z'], weighted_mean", async function() {
             var table = perspective.table(data2);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "mean", column: ["x"]}, {op: "weighted mean", column: ["x", "y"]}]
             });
             var answer = [{__ROW_PATH__: [], x: 2.5, "x|y": 2.8333333333333335}, {__ROW_PATH__: [false], x: 3, "x|y": 3.3333333333333335}, {__ROW_PATH__: [true], x: 2, "x|y": 2.3333333333333335}];
@@ -68,7 +68,7 @@ module.exports = perspective => {
         it("['z'], mean", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "mean", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 2.5}, {__ROW_PATH__: [false], x: 3}, {__ROW_PATH__: [true], x: 2}];
@@ -81,7 +81,7 @@ module.exports = perspective => {
         it("['z'], first by index", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "first by index", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 1}, {__ROW_PATH__: [false], x: 2}, {__ROW_PATH__: [true], x: 1}];
@@ -94,7 +94,7 @@ module.exports = perspective => {
         it("['z'], last by index", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "last by index", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 4}, {__ROW_PATH__: [false], x: 4}, {__ROW_PATH__: [true], x: 3}];
@@ -107,7 +107,7 @@ module.exports = perspective => {
         it("['z'], last", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"],
+                row_pivots: ["z"],
                 aggregate: [{op: "last", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [false], x: 4}, {__ROW_PATH__: [true], x: 3}];
@@ -127,7 +127,7 @@ module.exports = perspective => {
         it("mean", async function() {
             var table = perspective.table([{x: 3, y: 1}, {x: 2, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
-                row_pivot: ["y"],
+                row_pivots: ["y"],
                 aggregate: [{op: "mean", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [1], x: 2.5}, {__ROW_PATH__: [2], x: 4}];
@@ -140,7 +140,7 @@ module.exports = perspective => {
         it("mean with 0", async function() {
             var table = perspective.table([{x: 3, y: 1}, {x: 3, y: 1}, {x: 0, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
-                row_pivot: ["y"],
+                row_pivots: ["y"],
                 aggregate: [{op: "mean", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 2.5}, {__ROW_PATH__: [1], x: 2}, {__ROW_PATH__: [2], x: 4}];
@@ -154,7 +154,7 @@ module.exports = perspective => {
             var table = perspective.table({x: "float", y: "integer"});
             table.update([{x: 3, y: 1}, {x: 3, y: 1}, {x: 0, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
-                row_pivot: ["y"],
+                row_pivots: ["y"],
                 aggregate: [{op: "mean", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 2.5}, {__ROW_PATH__: [1], x: 2}, {__ROW_PATH__: [2], x: 4}];
@@ -167,7 +167,7 @@ module.exports = perspective => {
         it("sum", async function() {
             var table = perspective.table([{x: 3, y: 1}, {x: 2, y: 1}, {x: null, y: 1}, {x: null, y: 1}, {x: 4, y: 2}, {x: null, y: 2}]);
             var view = table.view({
-                row_pivot: ["y"],
+                row_pivots: ["y"],
                 aggregate: [{op: "sum", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 9}, {__ROW_PATH__: [1], x: 5}, {__ROW_PATH__: [2], x: 4}];
@@ -181,7 +181,7 @@ module.exports = perspective => {
             var table = perspective.table([{x: 3, y: 1}, {x: null, y: 1}, {x: null, y: 2}]);
             table.update([{x: 2, y: 1}, {x: null, y: 1}, {x: 4, y: 2}]);
             var view = table.view({
-                row_pivot: ["y"],
+                row_pivots: ["y"],
                 aggregate: [{op: "mean", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [1], x: 2.5}, {__ROW_PATH__: [2], x: 4}];
@@ -196,7 +196,7 @@ module.exports = perspective => {
             table.update([{x: 1, y: 1, z: "b"}, {x: 1, y: 1, z: "b"}, {x: null, y: 1, z: "b"}, {x: 4, y: 2, z: "b"}, {x: null, y: 2, z: "b"}]);
             table.update([{x: 2, y: 2, z: "c"}, {x: 3, y: 2, z: "c"}, {x: null, y: 2, z: "c"}, {x: 7, y: 2, z: "c"}]);
             var view = table.view({
-                row_pivot: ["y", "z"],
+                row_pivots: ["y", "z"],
                 aggregate: [{op: "mean", column: "x"}]
             });
             var answer = [
@@ -218,7 +218,7 @@ module.exports = perspective => {
         it("null in pivot column", async function() {
             var table = perspective.table([{x: null}, {x: "x"}, {x: "y"}]);
             var view = table.view({
-                row_pivot: ["x"],
+                row_pivots: ["x"],
                 aggregate: [{op: "distinct count", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 3}, {__ROW_PATH__: [null], x: 1}, {__ROW_PATH__: ["x"], x: 1}, {__ROW_PATH__: ["y"], x: 1}];
@@ -231,7 +231,7 @@ module.exports = perspective => {
         it("weighted mean", async function() {
             var table = perspective.table([{a: "a", x: 1, y: 200}, {a: "a", x: 2, y: 100}, {a: "a", x: 3, y: null}]);
             var view = table.view({
-                row_pivot: ["a"],
+                row_pivots: ["a"],
                 aggregate: [{op: "weighted mean", column: ["y", "x"], name: "y"}]
             });
             var answer = [{__ROW_PATH__: [], y: (1 * 200 + 2 * 100) / (1 + 2)}, {__ROW_PATH__: ["a"], y: (1 * 200 + 2 * 100) / (1 + 2)}];
@@ -246,7 +246,7 @@ module.exports = perspective => {
         it("sum abs", async function() {
             var table = perspective.table([{x: 3, y: 1}, {x: 2, y: 1}, {x: 1, y: 1}, {x: -1, y: 1}, {x: -2, y: 2}, {x: -3, y: 2}]);
             var view = table.view({
-                row_pivot: ["y"],
+                row_pivots: ["y"],
                 aggregate: [{op: "sum abs", column: "x"}]
             });
             var answer = [{__ROW_PATH__: [], x: 12}, {__ROW_PATH__: [1], x: 7}, {__ROW_PATH__: [2], x: 5}];
@@ -261,7 +261,7 @@ module.exports = perspective => {
         it("['x']", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x"]
+                row_pivots: ["x"]
             });
             var answer = [
                 {__ROW_PATH__: [], x: 10, y: 4, z: 2},
@@ -287,7 +287,7 @@ module.exports = perspective => {
             const table = perspective.table(schema, {index: "id"});
             table.update(rec1);
             let view = table.view({
-                row_pivot: ["id"],
+                row_pivots: ["id"],
                 aggregate: [{op: "sum", column: "pos"}]
             });
             let rec2 = [{id: 1, chg: 3}];
@@ -306,7 +306,7 @@ module.exports = perspective => {
                 var table = perspective.table(dataWithNulls);
 
                 var view = table.view({
-                    row_pivot: ["name"]
+                    row_pivots: ["name"]
                 });
 
                 const answer = [
@@ -330,7 +330,7 @@ module.exports = perspective => {
                 table.update(dataWithNull2);
 
                 var view = table.view({
-                    row_pivot: ["name"]
+                    row_pivots: ["name"]
                 });
 
                 const answer = [
@@ -350,7 +350,7 @@ module.exports = perspective => {
         it("['x'] has a schema", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x"]
+                row_pivots: ["x"]
             });
             let result2 = await view.schema();
             expect(result2).toEqual({x: "integer", y: "integer", z: "integer"});
@@ -361,7 +361,7 @@ module.exports = perspective => {
         it("['x'] translates type `string` to `integer` when pivoted by row", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x"],
+                row_pivots: ["x"],
                 aggregate: [{column: "y", op: "distinct count"}]
             });
             let result2 = await view.schema();
@@ -373,7 +373,7 @@ module.exports = perspective => {
         it("['x'] translates type `integer` to `float` when pivoted by row", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["y"],
+                row_pivots: ["y"],
                 aggregate: [{column: "x", op: "avg"}]
             });
             let result2 = await view.schema();
@@ -385,7 +385,7 @@ module.exports = perspective => {
         it("['x'] does not translate type when only pivoted by column", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                column_pivot: ["y"],
+                column_pivots: ["y"],
                 aggregate: [{column: "x", op: "avg"}]
             });
             let result2 = await view.schema();
@@ -397,7 +397,7 @@ module.exports = perspective => {
         it("['x'] has the correct # of rows", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x"]
+                row_pivots: ["x"]
             });
             let result2 = await view.num_rows();
             expect(result2).toEqual(5);
@@ -408,7 +408,7 @@ module.exports = perspective => {
         it("['x'] has the correct # of columns", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x"]
+                row_pivots: ["x"]
             });
             let result2 = await view.num_columns();
             expect(result2).toEqual(3);
@@ -419,7 +419,7 @@ module.exports = perspective => {
         it("['z']", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["z"]
+                row_pivots: ["z"]
             });
             var answer = [{__ROW_PATH__: [], x: 10, y: 4, z: 2}, {__ROW_PATH__: [false], x: 6, y: 2, z: 1}, {__ROW_PATH__: [true], x: 4, y: 2, z: 1}];
             let result2 = await view.to_json();
@@ -431,7 +431,7 @@ module.exports = perspective => {
         it("['x', 'z']", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x", "z"]
+                row_pivots: ["x", "z"]
             });
             var answer = [
                 {__ROW_PATH__: [], x: 10, y: 4, z: 2},
@@ -453,7 +453,7 @@ module.exports = perspective => {
         it("['x', 'z'] windowed", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x", "z"]
+                row_pivots: ["x", "z"]
             });
             var answer = [
                 {__ROW_PATH__: [1, true], x: 1, y: 1, z: 1},
@@ -473,7 +473,7 @@ module.exports = perspective => {
         it("['x', 'z'], pivot_depth = 1", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x", "z"],
+                row_pivots: ["x", "z"],
                 row_pivot_depth: 1
             });
             var answer = [
@@ -494,7 +494,7 @@ module.exports = perspective => {
         it("['y'] only, schema", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                column_pivot: ["y"]
+                column_pivots: ["y"]
             });
             let result2 = await view.schema();
             expect(result2).toEqual(meta);
@@ -505,7 +505,7 @@ module.exports = perspective => {
         it("['x'] only, column-oriented input", async function() {
             var table = perspective.table(data_7);
             var view = table.view({
-                column_pivot: ["z"]
+                column_pivots: ["z"]
             });
             let result2 = await view.to_json();
             expect(result2).toEqual([
@@ -521,7 +521,7 @@ module.exports = perspective => {
         it("['z'] only, column-oriented output", async function() {
             var table = perspective.table(data_7);
             var view = table.view({
-                column_pivot: ["z"]
+                column_pivots: ["z"]
             });
             let result2 = await view.to_columns();
             expect(result2).toEqual({
@@ -541,7 +541,7 @@ module.exports = perspective => {
         it("['y'] only sorted by ['x'] desc", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                column_pivot: ["y"],
+                column_pivots: ["y"],
                 sort: [["x", "desc"]]
             });
             var answer = [
@@ -559,7 +559,7 @@ module.exports = perspective => {
         it("['y'] only", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                column_pivot: ["y"]
+                column_pivots: ["y"]
             });
             var answer = [
                 {"a|x": 1, "a|y": "a", "a|z": true, "b|x": null, "b|y": null, "b|z": null, "c|x": null, "c|y": null, "c|z": null, "d|x": null, "d|y": null, "d|z": null},
@@ -576,8 +576,8 @@ module.exports = perspective => {
         it("['x'] by ['y']", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                column_pivot: ["y"],
-                row_pivot: ["x"]
+                column_pivots: ["y"],
+                row_pivots: ["x"]
             });
             var answer = [
                 {__ROW_PATH__: [], "a|x": 1, "a|y": 1, "a|z": 1, "b|x": 2, "b|y": 1, "b|z": 1, "c|x": 3, "c|y": 1, "c|z": 1, "d|x": 4, "d|y": 1, "d|z": 1},
@@ -595,7 +595,7 @@ module.exports = perspective => {
         it("['x', 'z']", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                column_pivot: ["x", "z"],
+                column_pivots: ["x", "z"],
                 aggregate: [{column: "y", op: "sum"}]
             });
             let result2 = await view.to_json();
@@ -627,8 +627,8 @@ module.exports = perspective => {
                 {x: 12, y: "C", z: false, a: "BB", b: "CC", c: "DD"}
             ]);
             var view = table.view({
-                column_pivot: ["z", "b"],
-                row_pivot: ["y", "a"],
+                column_pivots: ["z", "b"],
+                row_pivots: ["y", "a"],
                 aggregate: [{column: "x", op: "last"}]
             });
 
@@ -665,8 +665,8 @@ module.exports = perspective => {
                 {x: 12, y: "C", z: false}
             ]);
             var view = table.view({
-                column_pivot: ["z"],
-                row_pivot: ["y"],
+                column_pivots: ["z"],
+                row_pivots: ["y"],
                 sort: [["x", "desc"]]
             });
 
@@ -698,8 +698,8 @@ module.exports = perspective => {
                 {x: 12, y: "C", z: false}
             ]);
             var view = table.view({
-                column_pivot: ["y"],
-                row_pivot: ["z"],
+                column_pivots: ["y"],
+                row_pivots: ["z"],
                 sort: [["y", "col desc"]],
                 aggregate: [{column: "x", op: "sum"}, {column: "y", op: "any"}]
             });
@@ -713,8 +713,8 @@ module.exports = perspective => {
         it("['y'] by ['x'] sorted by ['x'] desc has the correct # of columns", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                column_pivot: ["y"],
-                row_pivot: ["x"],
+                column_pivots: ["y"],
+                row_pivots: ["x"],
                 sort: [["x", "desc"]]
             });
             let num_cols = await view.num_columns();
@@ -728,8 +728,8 @@ module.exports = perspective => {
         it("Should not expand past number of row pivots", async function() {
             var table = perspective.table(data);
             var view = table.view({
-                row_pivot: ["x"],
-                column_pivot: ["y"]
+                row_pivots: ["x"],
+                column_pivots: ["y"]
             });
             var expanded_idx = await view.expand(2);
             // invalid expands return the index

--- a/packages/perspective/test/js/to_format.js
+++ b/packages/perspective/test/js/to_format.js
@@ -42,7 +42,7 @@ module.exports = perspective => {
         it("one-sided views should have row paths", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                row_pivot: ["int"]
+                row_pivots: ["int"]
             });
             let json = await view.to_json();
             for (let d of json) {
@@ -53,7 +53,7 @@ module.exports = perspective => {
         it("one-sided views with start_col > 0 should have row paths", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                row_pivot: ["int"]
+                row_pivots: ["int"]
             });
             let json = await view.to_json({start_col: 1});
             for (let d of json) {
@@ -64,7 +64,7 @@ module.exports = perspective => {
         it("one-sided column-only views should not have row paths", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                column_pivot: ["int"]
+                column_pivots: ["int"]
             });
             let json = await view.to_json();
             for (let d of json) {
@@ -75,8 +75,8 @@ module.exports = perspective => {
         it("two-sided views should have row paths", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                row_pivot: ["int"],
-                column_pivot: ["string"]
+                row_pivots: ["int"],
+                column_pivots: ["string"]
             });
             let json = await view.to_json();
             for (let d of json) {
@@ -87,8 +87,8 @@ module.exports = perspective => {
         it("two-sided views with start_col > 0 should have row paths", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                row_pivot: ["int"],
-                column_pivot: ["string"]
+                row_pivots: ["int"],
+                column_pivots: ["string"]
             });
             let json = await view.to_json({start_col: 1});
             for (let d of json) {
@@ -99,8 +99,8 @@ module.exports = perspective => {
         it("two-sided sorted views with start_col > 0 should have row paths", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                row_pivot: ["int"],
-                column_pivot: ["string"],
+                row_pivots: ["int"],
+                column_pivots: ["string"],
                 sort: [["string", "desc"]]
             });
             let json = await view.to_json({start_col: 1});
@@ -114,8 +114,8 @@ module.exports = perspective => {
         it("should emit same number of column names as number of pivots", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view({
-                row_pivot: ["int"],
-                column_pivot: ["float", "string"],
+                row_pivots: ["int"],
+                column_pivots: ["float", "string"],
                 sort: [["int", "asc"]]
             });
             let json = await view.to_json();
@@ -185,7 +185,7 @@ module.exports = perspective => {
 
         it("Transitive arrow output 1-sided", async function() {
             let table = perspective.table(int_float_string_data);
-            let view = table.view({row_pivot: ["string"]});
+            let view = table.view({row_pivots: ["string"]});
             let json = await view.to_json();
             let arrow = await view.to_arrow();
             let table2 = perspective.table(arrow);
@@ -207,7 +207,7 @@ module.exports = perspective => {
 
         it("Transitive arrow output 2-sided", async function() {
             let table = perspective.table(int_float_string_data);
-            let view = table.view({row_pivot: ["string"], col_pivot: ["int"]});
+            let view = table.view({row_pivots: ["string"], col_pivot: ["int"]});
             let json = await view.to_json();
             let arrow = await view.to_arrow();
             let table2 = perspective.table(arrow);

--- a/packages/perspective/test/js/to_format.js
+++ b/packages/perspective/test/js/to_format.js
@@ -207,7 +207,7 @@ module.exports = perspective => {
 
         it("Transitive arrow output 2-sided", async function() {
             let table = perspective.table(int_float_string_data);
-            let view = table.view({row_pivots: ["string"], col_pivot: ["int"]});
+            let view = table.view({row_pivots: ["string"], column_pivots: ["int"]});
             let json = await view.to_json();
             let arrow = await view.to_arrow();
             let table2 = perspective.table(arrow);
@@ -229,7 +229,7 @@ module.exports = perspective => {
 
         it("Transitive arrow output 2-sided column only", async function() {
             let table = perspective.table(int_float_string_data);
-            let view = table.view({col_pivot: ["string"]});
+            let view = table.view({column_pivots: ["string"]});
             let json = await view.to_json();
             let arrow = await view.to_arrow();
             let table2 = perspective.table(arrow);

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -229,7 +229,7 @@ module.exports = perspective => {
                 }
             ]);
             table2.update(data);
-            let view2 = table2.view({aggregate: [{op: "count", column: "yes/no"}]});
+            let view2 = table2.view({columns: ["yes/no"], aggregates: {"yes/no": "count"}});
             let result = await view2.to_json();
             let expected = [{"yes/no": "yes"}, {"yes/no": "no"}, {"yes/no": "yes"}, {"yes/no": "no"}, {"yes/no": "yes"}, {"yes/no": "no"}, {"yes/no": "yes"}, {"yes/no": "no"}];
             expect(result).toEqual(expected);
@@ -458,7 +458,7 @@ module.exports = perspective => {
             var table = perspective.table(meta, {index: "y"});
             var view = table.view({
                 row_pivots: ["z", "y"],
-                aggregate: []
+                columns: []
             });
             table.update(data);
 
@@ -554,7 +554,7 @@ module.exports = perspective => {
             table.update([{x: 2, y: null}]);
             var view = table.view({
                 row_pivots: ["x"],
-                aggregate: [{op: "sum", column: "y"}]
+                columns: ["y"]
             });
             let json = await view.to_json();
             expect(json).toEqual([{__ROW_PATH__: [], y: 1}, {__ROW_PATH__: [1], y: 1}, {__ROW_PATH__: [2], y: 0}]);

--- a/packages/perspective/test/js/updates.js
+++ b/packages/perspective/test/js/updates.js
@@ -457,7 +457,7 @@ module.exports = perspective => {
         it("update with depth expansion", async function() {
             var table = perspective.table(meta, {index: "y"});
             var view = table.view({
-                row_pivot: ["z", "y"],
+                row_pivots: ["z", "y"],
                 aggregate: []
             });
             table.update(data);
@@ -553,7 +553,7 @@ module.exports = perspective => {
             var table = perspective.table([{x: 1, y: 1}, {x: 2, y: 1}], {index: "x"});
             table.update([{x: 2, y: null}]);
             var view = table.view({
-                row_pivot: ["x"],
+                row_pivots: ["x"],
                 aggregate: [{op: "sum", column: "y"}]
             });
             let json = await view.to_json();


### PR DESCRIPTION
A new API for the `table.view(config)` method, in order to make it more inline with the `<perspective-viewer>` web component API.  

* `row_pivot` is now `row_pivots`
* `column_pivot` is now `column_pivots`
* `aggregate` is now `columns` and `aggregates`;  `columns` is an array of column names, and `aggregates` is a dictionary of column name to aggregate function overrides.

These changes are backwards compatible for now;  attempts to use the old config properties will simple log a warning to the console.

Fixes #315 and #314 - though the latter was never technically broken.