### PR TITLE
Remove header rows for column-only views

### DIFF
--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -14,13 +14,16 @@ namespace perspective {
 
 template <typename CTX_T>
 t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
-    t_uindex end_row, t_uindex start_col, t_uindex end_col,
-    const std::shared_ptr<std::vector<t_tscalar>>& slice, std::vector<std::string> column_names)
+    t_uindex end_row, t_uindex start_col, t_uindex end_col, t_uindex row_offset,
+    t_uindex col_offset, const std::shared_ptr<std::vector<t_tscalar>>& slice,
+    std::vector<std::string> column_names)
     : m_ctx(ctx)
     , m_start_row(start_row)
     , m_end_row(end_row)
     , m_start_col(start_col)
     , m_end_col(end_col)
+    , m_row_offset(row_offset)
+    , m_col_offset(col_offset)
     , m_slice(slice)
     , m_column_names(column_names) {
     m_stride = m_end_col - m_start_col;
@@ -28,14 +31,16 @@ t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row
 
 template <typename CTX_T>
 t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
-    t_uindex end_row, t_uindex start_col, t_uindex end_col,
-    const std::shared_ptr<std::vector<t_tscalar>>& slice, std::vector<std::string> column_names,
-    std::vector<t_uindex> column_indices)
+    t_uindex end_row, t_uindex start_col, t_uindex end_col, t_uindex row_offset,
+    t_uindex col_offset, const std::shared_ptr<std::vector<t_tscalar>>& slice,
+    std::vector<std::string> column_names, std::vector<t_uindex> column_indices)
     : m_ctx(ctx)
     , m_start_row(start_row)
     , m_end_row(end_row)
     , m_start_col(start_col)
     , m_end_col(end_col)
+    , m_row_offset(row_offset)
+    , m_col_offset(col_offset)
     , m_slice(slice)
     , m_column_names(column_names)
     , m_column_indices(column_indices) {
@@ -49,6 +54,7 @@ t_data_slice<CTX_T>::~t_data_slice() {}
 template <typename CTX_T>
 t_tscalar
 t_data_slice<CTX_T>::get(t_uindex ridx, t_uindex cidx) const {
+    ridx += m_row_offset;
     t_uindex idx = get_slice_idx(ridx, cidx);
     t_tscalar rv;
     if (idx >= m_slice->size()) {

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -40,12 +40,12 @@ template <typename CTX_T>
 class PERSPECTIVE_EXPORT t_data_slice {
 public:
     t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
-        t_uindex start_col, t_uindex end_col,
+        t_uindex start_col, t_uindex end_col, t_uindex row_offset, t_uindex col_offset,
         const std::shared_ptr<std::vector<t_tscalar>>& slice,
         std::vector<std::string> column_names);
 
     t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
-        t_uindex start_col, t_uindex end_col,
+        t_uindex start_col, t_uindex end_col, t_uindex row_offset, t_uindex col_offset,
         const std::shared_ptr<std::vector<t_tscalar>>& slice,
         std::vector<std::string> column_names, std::vector<t_uindex> column_indices);
 
@@ -97,6 +97,8 @@ private:
     t_uindex m_end_row;
     t_uindex m_start_col;
     t_uindex m_end_col;
+    t_uindex m_row_offset;
+    t_uindex m_col_offset;
     t_uindex m_stride;
     std::shared_ptr<std::vector<t_tscalar>> m_slice;
     std::vector<std::string> m_column_names;

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -162,6 +162,8 @@ private:
     std::vector<t_fterm> m_filters;
     std::vector<t_sortspec> m_sorts;
     bool m_column_only;
+    t_uindex m_row_offset;
+    t_uindex m_col_offset;
 
     t_config m_config;
 };

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -327,7 +327,7 @@ export default function(Module) {
 
         const viewport = this.config.viewport ? this.config.viewport : {};
         const start_row = options.start_row || (viewport.top ? viewport.top : 0);
-        const end_row = (options.end_row || (viewport.height ? start_row + viewport.height : max_rows)) + (this.column_only ? 1 : 0);
+        const end_row = options.end_row || (viewport.height ? start_row + viewport.height : max_rows);
         const start_col = options.start_col || (viewport.left ? viewport.left : 0);
         const end_col = Math.min(max_cols, (options.end_col || (viewport.width ? start_col + viewport.width : max_cols)) * (hidden + 1));
 
@@ -363,9 +363,9 @@ export default function(Module) {
             formatter.addRow(data, row);
         }
 
-        if (this.column_only) {
+        /*         if (this.column_only) {
             data = formatter.slice(data, 1);
-        }
+        } */
 
         return formatter.formatData(data, options.config);
     };
@@ -950,7 +950,7 @@ export default function(Module) {
                     throw new Error(`Duplicate configuration parameter "${key}"`);
                 }
             } else if (key === "aggregate") {
-                console.warn(`Deprecated: "aggregate" config parameter has been replaced by "aggregates" amd "columns"`);
+                console.warn(`Deprecated: "aggregate" config parameter has been replaced by "aggregates" and "columns"`);
                 config[key] = _config[key];
             } else if (defaults.CONFIG_VALID_KEYS.indexOf(key) > -1) {
                 config[key] = _config[key];

--- a/packages/perspective/test/js/to_format.js
+++ b/packages/perspective/test/js/to_format.js
@@ -16,7 +16,25 @@ var int_float_string_data = [
 
 module.exports = perspective => {
     describe("data slice", function() {
-        it("data slice should respect start/end rows", async function() {
+        it("should filter out invalid start rows", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view();
+            let json = await view.to_json({
+                start_row: 5
+            });
+            expect(json).toEqual([]);
+        });
+
+        it("should filter out invalid start columns", async function() {
+            let table = perspective.table(int_float_string_data);
+            let view = table.view();
+            let json = await view.to_json({
+                start_col: 5
+            });
+            expect(json).toEqual([{}, {}, {}, {}]);
+        });
+
+        it("should respect start/end rows", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view();
             let json = await view.to_json({
@@ -28,7 +46,7 @@ module.exports = perspective => {
             expect(json[0]).toEqual(comparator);
         });
 
-        it("data slice should respect start/end columns", async function() {
+        it("should respect start/end columns", async function() {
             let table = perspective.table(int_float_string_data);
             let view = table.view();
             let json = await view.to_columns({
@@ -70,6 +88,26 @@ module.exports = perspective => {
             for (let d of json) {
                 expect(d.__ROW_PATH__).toBeUndefined();
             }
+        });
+
+        it("column-only views should not have header rows", async function() {
+            let table = perspective.table([{x: 1, y: "a"}, {x: 2, y: "b"}]);
+            let view = table.view({
+                column_pivots: ["x"]
+            });
+            let json = await view.to_json();
+            expect(json).toEqual([{"1|x": 1, "1|y": "a", "2|x": null, "2|y": null}, {"1|x": null, "1|y": null, "2|x": 2, "2|y": "b"}]);
+        });
+
+        it("column-only views should return correct windows of data", async function() {
+            let table = perspective.table([{x: 1, y: "a"}, {x: 2, y: "b"}]);
+            let view = table.view({
+                column_pivots: ["x"]
+            });
+            let json = await view.to_json({
+                start_row: 1
+            });
+            expect(json).toEqual([{"1|x": null, "1|y": null, "2|x": 2, "2|y": "b"}]);
         });
 
         it("two-sided views should have row paths", async function() {


### PR DESCRIPTION
Previously, the engine emitted a header row—containing all the data—for column-only views, which we sliced out in JS. This PR creates offsets inside `View` and `t_data_slice` in order to allow us to skip these rows in the engine.