### PR TITLE
Refactored data_slice to return t_tscalar

### DIFF
--- a/cpp/perspective/src/cpp/aggspec.cpp
+++ b/cpp/perspective/src/cpp/aggspec.cpp
@@ -93,6 +93,13 @@ t_aggspec::name() const {
     return m_name;
 }
 
+t_tscalar
+t_aggspec::name_scalar() const {
+    t_tscalar s;
+    s.set(m_name.c_str());
+    return s;
+}
+
 std::string
 t_aggspec::disp_name() const {
     return m_disp_name;

--- a/cpp/perspective/src/cpp/context_one.cpp
+++ b/cpp/perspective/src/cpp/context_one.cpp
@@ -195,6 +195,17 @@ t_ctx1::get_aggregate(t_uindex idx) const {
     return m_config.get_aggregates()[idx];
 }
 
+t_tscalar
+t_ctx1::get_aggregate_name(t_uindex idx) const {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    t_tscalar s;
+    if (idx >= m_config.get_num_aggregates())
+        return s;
+    s.set(m_config.get_aggregates()[idx].name_scalar());
+    return s;
+}
+
 std::vector<t_aggspec>
 t_ctx1::get_aggregates() const {
     PSP_TRACE_SENTINEL();

--- a/cpp/perspective/src/cpp/context_two.cpp
+++ b/cpp/perspective/src/cpp/context_two.cpp
@@ -541,6 +541,17 @@ t_ctx2::get_aggregates() const {
     return m_config.get_aggregates();
 }
 
+t_tscalar
+t_ctx2::get_aggregate_name(t_uindex idx) const {
+    PSP_TRACE_SENTINEL();
+    PSP_VERBOSE_ASSERT(m_init, "touching uninited object");
+    t_tscalar s;
+    if (idx >= m_config.get_num_aggregates())
+        return s;
+    s.set(m_config.get_aggregates()[idx].name_scalar());
+    return s;
+}
+
 void
 t_ctx2::set_depth(t_header header, t_depth depth) {
     t_depth new_depth;

--- a/cpp/perspective/src/cpp/data_slice.cpp
+++ b/cpp/perspective/src/cpp/data_slice.cpp
@@ -16,7 +16,7 @@ template <typename CTX_T>
 t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
     t_uindex end_row, t_uindex start_col, t_uindex end_col, t_uindex row_offset,
     t_uindex col_offset, const std::shared_ptr<std::vector<t_tscalar>>& slice,
-    std::vector<std::string> column_names)
+    std::vector<std::vector<t_tscalar>> column_names)
     : m_ctx(ctx)
     , m_start_row(start_row)
     , m_end_row(end_row)
@@ -33,7 +33,7 @@ template <typename CTX_T>
 t_data_slice<CTX_T>::t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row,
     t_uindex end_row, t_uindex start_col, t_uindex end_col, t_uindex row_offset,
     t_uindex col_offset, const std::shared_ptr<std::vector<t_tscalar>>& slice,
-    std::vector<std::string> column_names, std::vector<t_uindex> column_indices)
+    std::vector<std::vector<t_tscalar>> column_names, std::vector<t_uindex> column_indices)
     : m_ctx(ctx)
     , m_start_row(start_row)
     , m_end_row(end_row)
@@ -85,7 +85,7 @@ t_data_slice<CTX_T>::get_slice() const {
 }
 
 template <typename CTX_T>
-const std::vector<std::string>&
+const std::vector<std::vector<t_tscalar>>&
 t_data_slice<CTX_T>::get_column_names() const {
     return m_column_names;
 }

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -293,9 +293,8 @@ View<t_ctx2>::get_data(
     row_path.set("__ROW_PATH__");
     cols.insert(cols.begin(), std::vector<t_tscalar>{row_path});
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(slice);
-    auto data_slice_ptr
-        = std::make_shared<t_data_slice<t_ctx2>>(m_ctx, start_row, end_row, start_col, end_col,
-            m_row_offset, m_col_offset, slice_ptr, cols, column_indices);
+    auto data_slice_ptr = std::make_shared<t_data_slice<t_ctx2>>(m_ctx, start_row, end_row,
+        start_col, end_col, m_row_offset, m_col_offset, slice_ptr, cols, column_indices);
     return data_slice_ptr;
 }
 

--- a/cpp/perspective/src/cpp/view.cpp
+++ b/cpp/perspective/src/cpp/view.cpp
@@ -105,9 +105,9 @@ View<t_ctx2>::num_columns() const {
 
 // Metadata construction
 template <typename CTX_T>
-std::vector<std::string>
-View<CTX_T>::_column_names(bool skip, std::int32_t depth) const {
-    std::vector<std::string> names;
+std::vector<std::vector<t_tscalar>>
+View<CTX_T>::column_names(bool skip, std::int32_t depth) const {
+    std::vector<std::vector<t_tscalar>> names;
     std::vector<std::string> aggregate_names;
 
     const std::vector<t_aggspec> aggs = m_ctx->get_aggregates();
@@ -116,7 +116,6 @@ View<CTX_T>::_column_names(bool skip, std::int32_t depth) const {
     }
 
     for (t_uindex key = 0, max = m_ctx->unity_get_column_count(); key != max; ++key) {
-        std::stringstream col_name;
         std::string name = aggregate_names[key % aggregate_names.size()];
 
         if (name == "psp_okey") {
@@ -128,43 +127,30 @@ View<CTX_T>::_column_names(bool skip, std::int32_t depth) const {
             continue;
         }
 
+        std::vector<t_tscalar> new_path;
         for (auto path = col_path.rbegin(); path != col_path.rend(); ++path) {
-            std::string path_name = path->to_string();
-            // ensure that boolean columns are correctly represented
-            if (path->get_dtype() == DTYPE_BOOL) {
-                if (path_name == "0") {
-                    col_name << "false";
-                } else {
-                    col_name << "true";
-                }
-            } else {
-                col_name << path_name;
-            }
-            col_name << m_separator;
+            new_path.push_back(*path);
         }
-
-        col_name << name;
-        names.push_back(col_name.str());
+        new_path.push_back(m_ctx->get_aggregate_name(key % aggregate_names.size()));
+        names.push_back(new_path);
     }
 
     return names;
 }
 
 template <>
-std::vector<std::string>
-View<t_ctx0>::_column_names(bool skip, std::int32_t depth) const {
-    std::vector<std::string> names;
-    std::vector<std::string> aggregate_names = m_ctx->get_column_names();
+std::vector<std::vector<t_tscalar>>
+View<t_ctx0>::column_names(bool skip, std::int32_t depth) const {
+    std::vector<std::vector<t_tscalar>> names;
 
     for (t_uindex key = 0, max = m_ctx->unity_get_column_count(); key != max; ++key) {
-        std::stringstream col_name;
-
-        col_name << aggregate_names[key];
-        if (col_name.str() == "psp_okey") {
+        t_tscalar name = m_ctx->get_column_name(key);
+        if (name.to_string() == "psp_okey") {
             continue;
         };
-
-        names.push_back(col_name.str());
+        std::vector<t_tscalar> col_path;
+        col_path.push_back(name);
+        names.push_back(col_path);
     }
 
     return names;
@@ -184,12 +170,10 @@ View<CTX_T>::schema() const {
         types[names[i]] = _types[i];
     }
 
-    auto col_names = _column_names(false);
-    for (const std::string& name : col_names) {
+    auto col_names = column_names(false);
+    for (const std::vector<t_tscalar>& name : col_names) {
         // Pull out the main aggregate column
-        std::size_t last_delimiter = name.find_last_of(m_separator);
-        std::string agg_name = name.substr(last_delimiter + 1);
-
+        std::string agg_name = name.back().to_string();
         std::string type_string = dtype_to_str(types[agg_name]);
         new_schema[agg_name] = type_string;
 
@@ -213,11 +197,11 @@ View<t_ctx0>::schema() const {
         types[names[i]] = _types[i];
     }
 
-    std::vector<std::string> column_names = _column_names(false);
+    std::vector<std::vector<t_tscalar>> cols = column_names(false);
     std::map<std::string, std::string> new_schema;
 
-    for (std::size_t i = 0, max = column_names.size(); i != max; ++i) {
-        std::string name = column_names[i];
+    for (std::size_t i = 0, max = cols.size(); i != max; ++i) {
+        std::string name = cols[i].back().to_string();
         if (name == "psp_okey") {
             continue;
         }
@@ -233,7 +217,7 @@ View<t_ctx0>::get_data(
     t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col) {
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
         m_ctx->get_data(start_row, end_row, start_col, end_col));
-    auto col_names = _column_names();
+    auto col_names = column_names();
     auto data_slice_ptr = std::make_shared<t_data_slice<t_ctx0>>(m_ctx, start_row, end_row,
         start_col, end_col, m_row_offset, m_col_offset, slice_ptr, col_names);
     return data_slice_ptr;
@@ -245,8 +229,10 @@ View<t_ctx1>::get_data(
     t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col) {
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(
         m_ctx->get_data(start_row, end_row, start_col, end_col));
-    auto col_names = _column_names();
-    col_names.insert(col_names.begin(), "__ROW_PATH__");
+    auto col_names = column_names();
+    t_tscalar row_path;
+    row_path.set("__ROW_PATH__");
+    col_names.insert(col_names.begin(), std::vector<t_tscalar>{row_path});
     auto data_slice_ptr = std::make_shared<t_data_slice<t_ctx1>>(m_ctx, start_row, end_row,
         start_col, end_col, m_row_offset, m_col_offset, slice_ptr, col_names);
     return data_slice_ptr;
@@ -258,7 +244,7 @@ View<t_ctx2>::get_data(
     t_uindex start_row, t_uindex end_row, t_uindex start_col, t_uindex end_col) {
     std::vector<t_tscalar> slice;
     std::vector<t_uindex> column_indices;
-    std::vector<std::string> column_names;
+    std::vector<std::vector<t_tscalar>> cols;
     bool is_sorted = m_sorts.size() > 0;
 
     if (is_column_only()) {
@@ -280,7 +266,7 @@ View<t_ctx2>::get_data(
             }
         }
 
-        column_names = _column_names(true, depth);
+        cols = column_names(true, depth);
         column_indices = std::vector<t_uindex>(column_indices.begin() + start_col,
             column_indices.begin() + std::min(end_col, (t_uindex)column_indices.size()));
 
@@ -300,15 +286,16 @@ View<t_ctx2>::get_data(
                 iter++;
         }
     } else {
-        column_names = _column_names();
+        cols = column_names();
         slice = m_ctx->get_data(start_row, end_row, start_col, end_col);
     }
-
-    column_names.insert(column_names.begin(), "__ROW_PATH__");
+    t_tscalar row_path;
+    row_path.set("__ROW_PATH__");
+    cols.insert(cols.begin(), std::vector<t_tscalar>{row_path});
     auto slice_ptr = std::make_shared<std::vector<t_tscalar>>(slice);
     auto data_slice_ptr
         = std::make_shared<t_data_slice<t_ctx2>>(m_ctx, start_row, end_row, start_col, end_col,
-            m_row_offset, m_col_offset, slice_ptr, column_names, column_indices);
+            m_row_offset, m_col_offset, slice_ptr, cols, column_indices);
     return data_slice_ptr;
 }
 

--- a/cpp/perspective/src/include/perspective/aggspec.h
+++ b/cpp/perspective/src/include/perspective/aggspec.h
@@ -65,6 +65,7 @@ public:
         t_uindex agg_one_idx, t_uindex agg_two_idx, double agg_one_weight,
         double agg_two_weight);
     std::string name() const;
+    t_tscalar name_scalar() const;
     std::string disp_name() const;
     t_aggtype agg() const;
     std::string agg_str() const;

--- a/cpp/perspective/src/include/perspective/context_one.h
+++ b/cpp/perspective/src/include/perspective/context_one.h
@@ -35,6 +35,7 @@ public:
     t_index close(t_index idx);
 
     t_aggspec get_aggregate(t_uindex idx) const;
+    t_tscalar get_aggregate_name(t_uindex idx) const;
     std::vector<t_aggspec> get_aggregates() const;
     std::vector<t_tscalar> get_row_path(t_index idx) const;
     void set_depth(t_depth depth);

--- a/cpp/perspective/src/include/perspective/context_two.h
+++ b/cpp/perspective/src/include/perspective/context_two.h
@@ -44,6 +44,7 @@ public:
     std::vector<t_tscalar> get_column_path_userspace(t_index idx) const;
 
     std::vector<t_aggspec> get_aggregates() const;
+    t_tscalar get_aggregate_name(t_uindex idx) const;
 
     void column_sort_by(const std::vector<t_sortspec>& sortby);
 

--- a/cpp/perspective/src/include/perspective/data_slice.h
+++ b/cpp/perspective/src/include/perspective/data_slice.h
@@ -42,12 +42,12 @@ public:
     t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
         t_uindex start_col, t_uindex end_col, t_uindex row_offset, t_uindex col_offset,
         const std::shared_ptr<std::vector<t_tscalar>>& slice,
-        std::vector<std::string> column_names);
+        std::vector<std::vector<t_tscalar>> column_names);
 
     t_data_slice(std::shared_ptr<CTX_T> ctx, t_uindex start_row, t_uindex end_row,
         t_uindex start_col, t_uindex end_col, t_uindex row_offset, t_uindex col_offset,
         const std::shared_ptr<std::vector<t_tscalar>>& slice,
-        std::vector<std::string> column_names, std::vector<t_uindex> column_indices);
+        std::vector<std::vector<t_tscalar>> column_names, std::vector<t_uindex> column_indices);
 
     ~t_data_slice();
 
@@ -75,7 +75,7 @@ public:
     // Getters
     std::shared_ptr<CTX_T> get_context() const;
     std::shared_ptr<std::vector<t_tscalar>> get_slice() const;
-    const std::vector<std::string>& get_column_names() const;
+    const std::vector<std::vector<t_tscalar>>& get_column_names() const;
     const std::vector<t_uindex>& get_column_indices() const;
     t_get_data_extents get_data_extents() const;
     t_uindex get_stride() const;
@@ -101,7 +101,7 @@ private:
     t_uindex m_col_offset;
     t_uindex m_stride;
     std::shared_ptr<std::vector<t_tscalar>> m_slice;
-    std::vector<std::string> m_column_names;
+    std::vector<std::vector<t_tscalar>> m_column_names;
     std::vector<t_uindex> m_column_indices;
 };
 } // end namespace perspective

--- a/cpp/perspective/src/include/perspective/emscripten.h
+++ b/cpp/perspective/src/include/perspective/emscripten.h
@@ -42,7 +42,8 @@ namespace binding {
      */
     template <>
     emscripten::val scalar_to(const t_tscalar& scalar);
-    emscripten::val scalar_to_val(const t_tscalar& scalar, bool cast_double = false);
+    emscripten::val scalar_to_val(
+        const t_tscalar& scalar, bool cast_double = false, bool cast_string = false);
 
     template <>
     emscripten::val scalar_vec_to(const std::vector<t_tscalar>& scalars, std::uint32_t idx);

--- a/cpp/perspective/src/include/perspective/view.h
+++ b/cpp/perspective/src/include/perspective/view.h
@@ -76,9 +76,10 @@ public:
      * individual column names will be joined with a separator character
      * specified by the user, or defaulting to "|".
      *
-     * @return std::vector<std::string>
+     * @return std::vector<std::vector<t_tscalar>>
      */
-    std::vector<std::string> _column_names(bool skip = false, std::int32_t depth = 0) const;
+    std::vector<std::vector<t_tscalar>> column_names(
+        bool skip = false, std::int32_t depth = 0) const;
 
     /**
      * @brief Returns shared pointer to a t_data_slice object, which contains the

--- a/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
+++ b/packages/perspective-viewer-hypergrid/src/js/hypergrid.js
@@ -237,7 +237,7 @@ bindTemplate(TEMPLATE, style)(
                 );
                 this.grid.localization.add("FinanceFloat", float_formatter);
 
-                const integer_formatter = null_formatter(new this.grid.localization.NumberFormatter("en-US", {}));
+                const integer_formatter = null_formatter(new this.grid.localization.NumberFormatter("en-us", {}));
                 this.grid.localization.add("FinanceInteger", integer_formatter);
 
                 const datetime_formatter = null_formatter(

--- a/packages/perspective/src/js/perspective.js
+++ b/packages/perspective/src/js/perspective.js
@@ -300,6 +300,26 @@ export default function(Module) {
         return hidden;
     };
 
+    function col_path_vector_to_string(vector) {
+        let extracted = [];
+        for (let i = 0; i < vector.size(); i++) {
+            extracted.push(__MODULE__.scalar_vec_to_string(vector, i));
+        }
+        vector.delete();
+        return extracted;
+    }
+
+    const extract_vector_scalar = function(vector) {
+        // handles deletion already - do not call delete() on the input vector again
+        let extracted = [];
+        for (let i = 0; i < vector.size(); i++) {
+            let item = vector.get(i);
+            extracted.push(col_path_vector_to_string(item));
+        }
+        vector.delete();
+        return extracted;
+    };
+
     /**
      * The schema of this {@link module:perspective~view}. A schema is an Object, the keys of which
      * are the columns of this {@link module:perspective~view}, and the values are their string type names.
@@ -316,7 +336,7 @@ export default function(Module) {
     };
 
     view.prototype._column_names = function(skip = false, depth = 0) {
-        return extract_vector(this._View._column_names(skip, depth));
+        return extract_vector_scalar(this._View.column_names(skip, depth)).map(x => x.join(defaults.COLUMN_SEPARATOR_STRING));
     };
 
     const to_format = async function(options, formatter) {
@@ -335,7 +355,8 @@ export default function(Module) {
         const nidx = ["zero", "one", "two"][num_sides];
 
         const slice = __MODULE__[`get_data_slice_${nidx}`](this._View, start_row, end_row, start_col, end_col);
-        const col_names = extract_vector(slice.get_column_names());
+        const ns = slice.get_column_names();
+        const col_names = extract_vector_scalar(ns).map(x => x.join(defaults.COLUMN_SEPARATOR_STRING));
 
         let data = formatter.initDataValue();
         for (let ridx = start_row; ridx < end_row; ridx++) {

--- a/packages/perspective/test/js/pivots.js
+++ b/packages/perspective/test/js/pivots.js
@@ -24,6 +24,13 @@ var data_7 = {
     z: [true, false, true, false]
 };
 
+var data_8 = {
+    w: [1.5, 2.5, 3.5, 4.5],
+    x: [1, 2, 3, 4],
+    y: ["a", "b", "c", "d"],
+    z: [new Date(1555126035065), new Date(1555126035065), new Date(1555026035065), new Date(1555026035065)]
+};
+
 module.exports = perspective => {
     describe("Aggregate", function() {
         it("['z'], sum", async function() {
@@ -512,6 +519,23 @@ module.exports = perspective => {
             });
             let result2 = await view.schema();
             expect(result2).toEqual(meta);
+            view.delete();
+            table.delete();
+        });
+
+        it("['z'] only, datetime column", async function() {
+            var table = perspective.table(data_8);
+            var view = table.view({
+                column_pivots: ["z"],
+                columns: ["x", "y"]
+            });
+            let result2 = await view.to_columns();
+            expect(result2).toEqual({
+                "2019-4-11 23:40:35|x": [null, null, 3, 4],
+                "2019-4-11 23:40:35|y": [null, null, "c", "d"],
+                "2019-4-13 03:27:15|x": [1, 2, null, null],
+                "2019-4-13 03:27:15|y": ["a", "b", null, null]
+            });
             view.delete();
             table.delete();
         });


### PR DESCRIPTION
This fixes formatting for headers of `column-pivots`, like e.g. `datetime`.

`View.column_names()` now returns `std::vector<std::vector<t_tscalar>>`, and string rendering of these types is now handled in Javascript.  