### PR TITLE
Called save and restore with the correct context

### DIFF
--- a/packages/perspective-viewer/src/js/viewer.js
+++ b/packages/perspective-viewer/src/js/viewer.js
@@ -484,7 +484,7 @@ class PerspectiveViewer extends ActionElement {
             }
         }
         if (this._plugin.save) {
-            obj.plugin_config = this._plugin.save();
+            obj.plugin_config = this._plugin.save.call(this);
         }
         return obj;
     }
@@ -506,7 +506,7 @@ class PerspectiveViewer extends ActionElement {
             this.setAttribute(key, val);
         }
         if (this._plugin.restore && x.plugin_config) {
-            this._plugin.restore(x.plugin_config);
+            this._plugin.restore.call(this, x.plugin_config);
         }
         await this._debounce_update();
     }


### PR DESCRIPTION
To match the other plugin calls, I believe these methods should also use the chart node as the context.